### PR TITLE
Handle URL edge cases and message entity types

### DIFF
--- a/app/adapters/telegram_bot.py
+++ b/app/adapters/telegram_bot.py
@@ -556,9 +556,8 @@ class TelegramBot:
         text_full = getattr(message, "text", None) or getattr(message, "caption", "") or None
 
         # Entities
-        entities_obj = (getattr(message, "entities", None) or []) + (
-            getattr(message, "caption_entities", None) or []
-        )
+        entities_obj = list(getattr(message, "entities", []) or [])
+        entities_obj.extend(list(getattr(message, "caption_entities", []) or []))
         try:
 
             def _ent_to_dict(e: Any) -> dict:

--- a/app/config.py
+++ b/app/config.py
@@ -93,7 +93,7 @@ def load_config() -> AppConfig:
         log_level=os.getenv("LOG_LEVEL", "INFO"),
         request_timeout_sec=int(os.getenv("REQUEST_TIMEOUT_SEC", "60")),
         preferred_lang=os.getenv("PREFERRED_LANG", "auto"),
-        debug_payloads=os.getenv("DEBUG_PAYLOADS", "0") in ("1", "true", "True"),
+        debug_payloads=os.getenv("DEBUG_PAYLOADS", "0").lower() in ("1", "true"),
     )
 
     return AppConfig(telegram=telegram, firecrawl=firecrawl, openrouter=openrouter, runtime=runtime)

--- a/app/core/url_utils.py
+++ b/app/core/url_utils.py
@@ -27,6 +27,8 @@ def normalize_url(url: str) -> str:
     - Sort query params and remove common tracking params
     - Collapse trailing slash
     """
+    if "://" not in url:
+        url = f"http://{url}"
     p = urlparse(url)
     scheme = (p.scheme or "http").lower()
     netloc = p.netloc.lower()
@@ -38,7 +40,9 @@ def normalize_url(url: str) -> str:
 
     # Filter and sort query params
     query_pairs = [
-        (k, v) for k, v in parse_qsl(p.query, keep_blank_values=True) if k not in TRACKING_PARAMS
+        (k, v)
+        for k, v in parse_qsl(p.query, keep_blank_values=True)
+        if k.lower() not in TRACKING_PARAMS
     ]
     query_pairs.sort(key=lambda x: (x[0], x[1]))
     query = urlencode(query_pairs)

--- a/tests/test_media_snapshot.py
+++ b/tests/test_media_snapshot.py
@@ -165,8 +165,8 @@ class TestMediaSnapshot(unittest.TestCase):
                 super().__init__()
                 self.text = "Hello"
                 self.caption = "World"
-                self.entities = [_Ent("bold")]
-                self.caption_entities = [_Ent("url")]
+                self.entities = (_Ent("bold"),)
+                self.caption_entities = (_Ent("url"),)
 
         self.bot._persist_message_snapshot(self.req_id, Msg())
         row = self.db.fetchone(

--- a/tests/test_url_utils.py
+++ b/tests/test_url_utils.py
@@ -13,6 +13,11 @@ class TestURLUtils(unittest.TestCase):
         self.assertEqual(normalize_url("http://example.com/"), "http://example.com/")
         self.assertEqual(normalize_url("http://example.com/path/"), "http://example.com/path")
 
+    def test_normalize_url_handles_missing_scheme_and_tracking(self):
+        self.assertEqual(normalize_url("example.com"), "http://example.com/")
+        url = "EXAMPLE.com/Path?A=1&UTM_Source=x"
+        self.assertEqual(normalize_url(url), "http://example.com/Path?A=1")
+
     def test_url_hash(self):
         norm = normalize_url("http://example.com/path?a=1")
         h = url_hash_sha256(norm)


### PR DESCRIPTION
## Summary
- normalize URLs without a scheme and drop tracking params case-insensitively
- prevent tuple/list type errors when merging telegram entities
- parse DEBUG_PAYLOADS env var case-insensitively

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest`
- `PYENV_VERSION=3.11.12 ruff check . --fix`
- `PYENV_VERSION=3.11.12 ruff format .`
- `PYENV_VERSION=3.11.12 mypy .` *(fails: unused `type: ignore` comments in tests and modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c67472adc0832c8a496d587e5c9633