### PR TITLE
Handle parallel request dedupe for file processing

### DIFF
--- a/app/adapters/content/llm_summarizer.py
+++ b/app/adapters/content/llm_summarizer.py
@@ -959,15 +959,22 @@ class LLMSummarizer:
             {"role": "user", "content": user_prompt},
         ]
 
-        async with self._sem():
-            llm = await self.openrouter.chat(
-                messages,
-                temperature=0.2,
-                max_tokens=512,
-                top_p=0.9,
-                request_id=req_id,
-                response_format=response_format,
+        try:
+            async with self._sem():
+                llm = await self.openrouter.chat(
+                    messages,
+                    temperature=0.2,
+                    max_tokens=512,
+                    top_p=0.9,
+                    request_id=req_id,
+                    response_format=response_format,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "metadata_completion_call_failed",
+                extra={"cid": correlation_id, "error": str(exc)},
             )
+            return {}
 
         asyncio.create_task(self._persist_llm_call(llm, req_id, correlation_id))
 

--- a/app/adapters/content/url_processor.py
+++ b/app/adapters/content/url_processor.py
@@ -481,7 +481,6 @@ class URLProcessor:
         for field in content_fields:
             value = summary.get(field)
             if field == "entities":
-                # Entities should be a dict with lists
                 if isinstance(value, dict) and any(
                     isinstance(v, list) and len(v) > 0 for v in value.values()
                 ):
@@ -491,7 +490,13 @@ class URLProcessor:
                 has_content = True
                 break
 
-        return has_content
+        if not has_content:
+            logger.debug(
+                "cached_summary_missing_optional_content",
+                extra={"missing_fields": content_fields},
+            )
+
+        return True
 
     def _get_missing_summary_fields(self, summary: dict[str, Any]) -> list[str]:
         """Get list of missing or empty essential fields."""


### PR DESCRIPTION
## Summary
- guard Database.create_request against dedupe races and reuse the existing request ID when a unique hash collides
- return the existing telegram snapshot instead of failing when insert_telegram_message sees concurrent inserts
- treat cached summaries with only essential fields as complete and make metadata completion resilient to transport errors
- add regression tests covering duplicate request creation and telegram snapshot inserts

## Testing
- uv run ruff check . --fix
- uv run ruff format .
- uv run mypy .
- uv run pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d373813928832cb3efedaa78b9c850