### PR TITLE
Add cancel command to Telegram bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Commands & usage
 - `/summarize <URL>` — Summarize a URL immediately.
 - `/summarize` — Bot will ask you to send a URL in the next message.
 - Multiple URLs in one message (or after `/summarize`): bot asks “Process N links?”; reply “yes/no”. Each link gets its own correlation ID and is processed sequentially.
- - `/summarize_all <URLs>` — Summarize multiple URLs from one message immediately, without confirmation.
+- `/summarize_all <URLs>` — Summarize multiple URLs from one message immediately, without confirmation.
+- `/cancel` — Cancel any pending `/summarize` URL prompt or multi-link confirmation.
 
 Local CLI summary runner
 - With the same environment variables exported (Firecrawl + OpenRouter keys, DB path, etc.), run `python -m app.cli.summary --url https://example.com/article`.

--- a/app/adapters/external/response_formatter.py
+++ b/app/adapters/external/response_formatter.py
@@ -173,6 +173,7 @@ class ResponseFormatter:
             "• `/help` — Show this help message\n"
             "• `/summarize <URL>` — Summarize a URL\n"
             "• `/summarize_all <URLs>` — Summarize multiple URLs from one message\n"
+            "• `/cancel` — Cancel any pending URL or multi-link requests\n"
             "• `/unread` — Show list of unread articles\n"
             "• `/read <ID>` — Mark article as read and view it\n"
             "• `/dbinfo` — Show database overview\n\n"

--- a/app/adapters/telegram/message_handler.py
+++ b/app/adapters/telegram/message_handler.py
@@ -42,17 +42,18 @@ class MessageHandler:
             audit_func=self._audit,
         )
 
+        self.url_handler = URLHandler(
+            response_formatter=response_formatter,
+            url_processor=url_processor,
+        )
+
         self.command_processor = CommandProcessor(
             cfg=cfg,
             response_formatter=response_formatter,
             db=db,
             url_processor=url_processor,
             audit_func=self._audit,
-        )
-
-        self.url_handler = URLHandler(
-            response_formatter=response_formatter,
-            url_processor=url_processor,
+            url_handler=self.url_handler,
         )
 
         self.message_router = MessageRouter(

--- a/app/adapters/telegram/message_router.py
+++ b/app/adapters/telegram/message_router.py
@@ -220,6 +220,12 @@ class MessageRouter:
                 self.url_handler.add_awaiting_user(uid)
             return
 
+        if text.startswith("/cancel"):
+            await self.command_processor.handle_cancel_command(
+                message, uid, correlation_id, interaction_id, start_time
+            )
+            return
+
         if text.startswith("/unread"):
             await self.command_processor.handle_unread_command(
                 message, uid, correlation_id, interaction_id, start_time

--- a/app/adapters/telegram/url_handler.py
+++ b/app/adapters/telegram/url_handler.py
@@ -41,6 +41,18 @@ class URLHandler:
         """Add user to pending multi-links confirmation."""
         self._pending_multi_links[uid] = urls
 
+    def cancel_pending_requests(self, uid: int) -> tuple[bool, bool]:
+        """Cancel any pending URL or multi-link confirmation requests for a user."""
+        awaiting_cancelled = uid in self._awaiting_url_users
+        if awaiting_cancelled:
+            self._awaiting_url_users.discard(uid)
+
+        multi_cancelled = uid in self._pending_multi_links
+        if multi_cancelled:
+            self._pending_multi_links.pop(uid, None)
+
+        return awaiting_cancelled, multi_cancelled
+
     async def handle_awaited_url(
         self,
         message: Any,


### PR DESCRIPTION
## Summary
- add a /cancel command that clears any pending URL prompt or multi-link confirmation for the requesting user
- route the new command through the message handler, extend help text, and update docs and tests

## Testing
- `uv run ruff check . --fix`
- `uv run ruff format .`
- `uv run mypy .`
- `uv run python -m unittest discover -s tests -p "test_*.py" -v`


------
https://chatgpt.com/codex/tasks/task_e_68d38a355930832c82091665daeb03fa