### PR TITLE
Add database verification command and integrity checks

### DIFF
--- a/app/adapters/telegram/message_router.py
+++ b/app/adapters/telegram/message_router.py
@@ -204,6 +204,12 @@ class MessageRouter:
             )
             return
 
+        if text.startswith("/dbverify"):
+            await self.command_processor.handle_dbverify_command(
+                message, uid, correlation_id, interaction_id, start_time
+            )
+            return
+
         if text.startswith("/summarize_all"):
             await self.command_processor.handle_summarize_all_command(
                 message, text, uid, correlation_id, interaction_id, start_time

--- a/app/db/database.py
+++ b/app/db/database.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import sqlite3
 from collections.abc import Iterable
@@ -335,6 +336,296 @@ class Database:
             return name
         except Exception:  # pragma: no cover - defensive
             return "..."
+
+    def verify_processing_integrity(
+        self,
+        *,
+        required_fields: Iterable[str] | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
+        """Verify that stored posts contain required processing artifacts."""
+
+        overview = self.get_database_overview()
+        required_default = [
+            "summary_250",
+            "summary_1000",
+            "key_ideas",
+            "topic_tags",
+            "entities",
+            "estimated_reading_time_min",
+            "key_stats",
+            "answered_questions",
+            "readability",
+            "seo_keywords",
+            "metadata",
+            "extractive_quotes",
+            "highlights",
+            "questions_answered",
+            "categories",
+            "topic_taxonomy",
+            "hallucination_risk",
+            "confidence",
+            "forwarded_post_extras",
+            "key_points_to_remember",
+        ]
+        required = list(dict.fromkeys(required_fields or required_default))
+
+        post_checks: dict[str, Any] = {
+            "required_fields": required,
+            "checked": 0,
+            "with_summary": 0,
+            "missing_summary": [],
+            "missing_fields": [],
+            "errors": [],
+            "links": {
+                "total_links": 0,
+                "posts_with_links": 0,
+                "missing_data": [],
+            },
+        }
+
+        query = (
+            "SELECT "
+            "r.id AS request_id, "
+            "r.type AS request_type, "
+            "r.status AS request_status, "
+            "r.input_url AS input_url, "
+            "r.normalized_url AS normalized_url, "
+            "r.fwd_from_chat_id AS fwd_from_chat_id, "
+            "r.fwd_from_msg_id AS fwd_from_msg_id, "
+            "s.json_payload AS summary_json, "
+            "cr.links_json AS links_json, "
+            "cr.status AS crawl_status "
+            "FROM requests r "
+            "LEFT JOIN summaries s ON s.request_id = r.id "
+            "LEFT JOIN crawl_results cr ON cr.request_id = r.id "
+            "ORDER BY r.id DESC"
+        )
+        params: tuple[Any, ...] = ()
+        if isinstance(limit, int) and limit > 0:
+            query += " LIMIT ?"
+            params = (limit,)
+
+        with self.connect() as conn:
+            rows = conn.execute(query, params).fetchall()
+
+        post_checks["checked"] = len(rows)
+        links_info = post_checks["links"]
+
+        for row in rows:
+            request_id = int(row["request_id"])
+            request_type = str(row["request_type"] or "unknown")
+            request_status = str(row["request_status"] or "unknown")
+            summary_json = row["summary_json"]
+            links_json = row["links_json"]
+
+            # Links coverage
+            link_count, link_valid, link_error = self._count_links_entries(links_json)
+            if link_valid:
+                links_info["total_links"] += link_count
+                links_info["posts_with_links"] += 1
+            elif request_type != "forward":
+                links_info["missing_data"].append(
+                    {
+                        "request_id": request_id,
+                        "type": request_type,
+                        "status": request_status,
+                        "source": self._describe_request_source(row),
+                        "reason": "invalid_links_json" if link_error else "absent_links_json",
+                    }
+                )
+                if link_error:
+                    post_checks["errors"].append(
+                        f"request {request_id}: links_json error ({link_error})"
+                    )
+
+            if summary_json is None or not str(summary_json).strip():
+                post_checks["missing_summary"].append(
+                    {
+                        "request_id": request_id,
+                        "type": request_type,
+                        "status": request_status,
+                        "source": self._describe_request_source(row),
+                    }
+                )
+                continue
+
+            post_checks["with_summary"] += 1
+            try:
+                payload = json.loads(summary_json)
+            except (TypeError, json.JSONDecodeError) as exc:
+                post_checks["errors"].append(f"request {request_id}: invalid summary_json ({exc})")
+                post_checks["missing_fields"].append(
+                    {
+                        "request_id": request_id,
+                        "type": request_type,
+                        "status": request_status,
+                        "source": self._describe_request_source(row),
+                        "missing": ["summary_json"],
+                    }
+                )
+                continue
+
+            if not isinstance(payload, dict):
+                post_checks["errors"].append(f"request {request_id}: summary_json not an object")
+                post_checks["missing_fields"].append(
+                    {
+                        "request_id": request_id,
+                        "type": request_type,
+                        "status": request_status,
+                        "source": self._describe_request_source(row),
+                        "missing": ["summary_object"],
+                    }
+                )
+                continue
+
+            missing: list[str] = []
+
+            def flag(field: str) -> None:
+                if field not in missing:
+                    missing.append(field)
+
+            # String fields should be non-empty strings
+            for field in ("summary_250", "summary_1000"):
+                value = payload.get(field)
+                if not isinstance(value, str) or not value.strip():
+                    flag(field)
+
+            # List-based fields (may be empty lists but must exist)
+            list_fields = [
+                "key_ideas",
+                "topic_tags",
+                "key_stats",
+                "answered_questions",
+                "seo_keywords",
+                "extractive_quotes",
+                "highlights",
+                "questions_answered",
+                "categories",
+                "topic_taxonomy",
+                "key_points_to_remember",
+            ]
+            for field in list_fields:
+                if not isinstance(payload.get(field), list):
+                    flag(field)
+
+            reading_time = payload.get("estimated_reading_time_min")
+            if not isinstance(reading_time, int) or reading_time < 0:
+                flag("estimated_reading_time_min")
+
+            entities = payload.get("entities")
+            if not isinstance(entities, dict):
+                flag("entities")
+            else:
+                for subfield in ("people", "organizations", "locations"):
+                    if not isinstance(entities.get(subfield), list):
+                        flag(f"entities.{subfield}")
+
+            readability = payload.get("readability")
+            if not isinstance(readability, dict):
+                flag("readability")
+            else:
+                if (
+                    not isinstance(readability.get("method"), str)
+                    or not readability["method"].strip()
+                ):
+                    flag("readability.method")
+                score = readability.get("score")
+                if not isinstance(score, (int, float)):
+                    flag("readability.score")
+                if (
+                    not isinstance(readability.get("level"), str)
+                    or not readability["level"].strip()
+                ):
+                    flag("readability.level")
+
+            metadata = payload.get("metadata")
+            if not isinstance(metadata, dict):
+                flag("metadata")
+            else:
+                for subfield in (
+                    "title",
+                    "canonical_url",
+                    "domain",
+                    "author",
+                    "published_at",
+                    "last_updated",
+                ):
+                    if subfield not in metadata:
+                        flag(f"metadata.{subfield}")
+
+            hallu_risk = payload.get("hallucination_risk")
+            if not isinstance(hallu_risk, str) or not hallu_risk.strip():
+                flag("hallucination_risk")
+
+            confidence = payload.get("confidence")
+            if not isinstance(confidence, (int, float)):
+                flag("confidence")
+
+            if "forwarded_post_extras" not in payload:
+                flag("forwarded_post_extras")
+            else:
+                forwarded_extras = payload.get("forwarded_post_extras")
+                if request_type == "forward":
+                    if not isinstance(forwarded_extras, dict):
+                        flag("forwarded_post_extras")
+                    else:
+                        for subfield in (
+                            "channel_id",
+                            "channel_title",
+                            "channel_username",
+                            "message_id",
+                            "post_datetime",
+                            "hashtags",
+                            "mentions",
+                        ):
+                            if subfield not in forwarded_extras:
+                                flag(f"forwarded_post_extras.{subfield}")
+
+            if missing:
+                post_checks["missing_fields"].append(
+                    {
+                        "request_id": request_id,
+                        "type": request_type,
+                        "status": request_status,
+                        "source": self._describe_request_source(row),
+                        "missing": missing,
+                    }
+                )
+
+        return {"overview": overview, "posts": post_checks}
+
+    def _describe_request_source(self, row: sqlite3.Row) -> str:
+        """Return a concise description of where the request came from."""
+        url = row["normalized_url"] or row["input_url"]
+        if isinstance(url, str) and url:
+            return url
+        chat_id = row["fwd_from_chat_id"]
+        msg_id = row["fwd_from_msg_id"]
+        if chat_id is not None and msg_id is not None:
+            return f"forward:{chat_id}/{msg_id}"
+        return f"request:{row['request_id']}"
+
+    def _count_links_entries(self, links_json: str | None) -> tuple[int, bool, str | None]:
+        """Return link count, validity flag, and optional error message."""
+        if links_json is None or str(links_json).strip() == "":
+            return 0, False, None
+        try:
+            parsed = json.loads(links_json)
+        except (TypeError, json.JSONDecodeError) as exc:
+            return 0, False, str(exc)
+
+        if isinstance(parsed, list):
+            return len(parsed), True, None
+        if isinstance(parsed, dict):
+            if "links" in parsed and isinstance(parsed["links"], list):
+                return len(parsed["links"]), True, None
+            total = 0
+            for value in parsed.values():
+                if isinstance(value, list):
+                    total += len(value)
+            return total, True, None
+        return 0, False, "links_json_not_iterable"
 
     def get_request_by_dedupe_hash(self, dedupe_hash: str) -> dict | None:
         row = self.fetchone("SELECT * FROM requests WHERE dedupe_hash = ?", (dedupe_hash,))

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 import unittest
@@ -170,6 +171,113 @@ class TestCommands(unittest.IsolatedAsyncioTestCase):
             self.assertTrue(any("Requests by status" in reply for reply in msg._replies))
             self.assertTrue(any("Totals" in reply for reply in msg._replies))
             self.assertFalse(any(db_path in reply for reply in msg._replies))
+
+    async def test_dbverify_command(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            bot = make_bot(os.path.join(tmp, "app.db"))
+            bot.response_formatter.MIN_MESSAGE_INTERVAL_MS = 0
+
+            base_summary = {
+                "summary_250": "Short summary.",
+                "summary_1000": "Long summary.",
+                "key_ideas": ["Idea"],
+                "topic_tags": ["#tag"],
+                "entities": {"people": [], "organizations": [], "locations": []},
+                "estimated_reading_time_min": 5,
+                "key_stats": [],
+                "answered_questions": [],
+                "readability": {"method": "FK", "score": 50.0, "level": "Standard"},
+                "seo_keywords": [],
+                "metadata": {
+                    "title": "Title",
+                    "canonical_url": "https://example.com/article",
+                    "domain": "example.com",
+                    "author": "Author",
+                    "published_at": "2024-01-01",
+                    "last_updated": "2024-01-01",
+                },
+                "extractive_quotes": [],
+                "highlights": [],
+                "questions_answered": [],
+                "categories": [],
+                "topic_taxonomy": [],
+                "hallucination_risk": "low",
+                "confidence": 1.0,
+                "forwarded_post_extras": None,
+                "key_points_to_remember": [],
+            }
+
+            rid_good = bot.db.create_request(
+                type_="url",
+                status="ok",
+                correlation_id="good",
+                chat_id=1,
+                user_id=1,
+                input_url="https://example.com/good",
+                normalized_url="https://example.com/good",
+                route_version=1,
+            )
+            bot.db.insert_summary(
+                request_id=rid_good,
+                lang="en",
+                json_payload=json.dumps(base_summary),
+            )
+            bot.db.insert_crawl_result(
+                request_id=rid_good,
+                source_url="https://example.com/good",
+                endpoint="/v1/scrape",
+                http_status=200,
+                status="ok",
+                options_json=json.dumps({}),
+                correlation_id="fc-good",
+                content_markdown="# md",
+                content_html=None,
+                structured_json=json.dumps({}),
+                metadata_json=json.dumps({}),
+                links_json=json.dumps(["https://example.com/other"]),
+                screenshots_paths_json=None,
+                raw_response_json=json.dumps({}),
+                latency_ms=100,
+                error_text=None,
+            )
+
+            bad_summary = dict(base_summary)
+            bad_summary.pop("summary_1000", None)
+
+            rid_bad = bot.db.create_request(
+                type_="url",
+                status="ok",
+                correlation_id="bad",
+                chat_id=1,
+                user_id=1,
+                input_url="https://example.com/bad",
+                normalized_url="https://example.com/bad",
+                route_version=1,
+            )
+            bot.db.insert_summary(
+                request_id=rid_bad,
+                lang="en",
+                json_payload=json.dumps(bad_summary),
+            )
+
+            bot.db.create_request(
+                type_="url",
+                status="pending",
+                correlation_id="missing",
+                chat_id=1,
+                user_id=1,
+                input_url="https://example.com/missing",
+                normalized_url="https://example.com/missing",
+                route_version=1,
+            )
+
+            msg = FakeMessage("/dbverify")
+            await bot._on_message(msg)
+
+            self.assertTrue(any("Database Verification" in reply for reply in msg._replies))
+            self.assertTrue(any("Missing summaries" in reply for reply in msg._replies))
+            self.assertTrue(any("Link coverage" in reply for reply in msg._replies))
+            self.assertTrue(any("summary_1000" in reply for reply in msg._replies))
 
 
 if __name__ == "__main__":

--- a/tests/test_database_helpers.py
+++ b/tests/test_database_helpers.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import tempfile
@@ -211,6 +212,133 @@ class TestDatabaseHelpers(unittest.TestCase):
         arow = self.db.fetchone("SELECT * FROM audit_logs WHERE id = ?", (aid,))
         self.assertIsNotNone(arow)
         self.assertEqual(arow["level"], "INFO")
+
+    def test_verify_processing_integrity(self):
+        base_summary = {
+            "summary_250": "Short summary.",
+            "summary_1000": "Longer summary text.",
+            "key_ideas": ["Idea"],
+            "topic_tags": ["#tag"],
+            "entities": {
+                "people": [],
+                "organizations": [],
+                "locations": [],
+            },
+            "estimated_reading_time_min": 5,
+            "key_stats": [],
+            "answered_questions": [],
+            "readability": {"method": "FK", "score": 50.0, "level": "Standard"},
+            "seo_keywords": [],
+            "metadata": {
+                "title": "Title",
+                "canonical_url": "https://example.com/article",
+                "domain": "example.com",
+                "author": "Author",
+                "published_at": "2024-01-01",
+                "last_updated": "2024-01-01",
+            },
+            "extractive_quotes": [],
+            "highlights": [],
+            "questions_answered": [],
+            "categories": [],
+            "topic_taxonomy": [],
+            "hallucination_risk": "low",
+            "confidence": 1.0,
+            "forwarded_post_extras": None,
+            "key_points_to_remember": [],
+        }
+
+        rid_good = self.db.create_request(
+            type_="url",
+            status="ok",
+            correlation_id="good",
+            chat_id=1,
+            user_id=1,
+            input_url="https://example.com/good",
+            normalized_url="https://example.com/good",
+            route_version=1,
+        )
+        self.db.insert_summary(
+            request_id=rid_good,
+            lang="en",
+            json_payload=json.dumps(base_summary),
+        )
+        self.db.insert_crawl_result(
+            request_id=rid_good,
+            source_url="https://example.com/good",
+            endpoint="/v1/scrape",
+            http_status=200,
+            status="ok",
+            options_json=json.dumps({}),
+            correlation_id="fc-good",
+            content_markdown="# md",
+            content_html=None,
+            structured_json=json.dumps({}),
+            metadata_json=json.dumps({}),
+            links_json=json.dumps(["https://example.com/other"]),
+            screenshots_paths_json=None,
+            raw_response_json=json.dumps({}),
+            latency_ms=100,
+            error_text=None,
+        )
+
+        bad_summary = copy.deepcopy(base_summary)
+        bad_summary.pop("summary_1000", None)
+        bad_summary["summary_250"] = ""
+        bad_summary.pop("metadata", None)
+
+        rid_bad = self.db.create_request(
+            type_="url",
+            status="ok",
+            correlation_id="bad",
+            chat_id=1,
+            user_id=1,
+            input_url="https://example.com/bad",
+            normalized_url="https://example.com/bad",
+            route_version=1,
+        )
+        self.db.insert_summary(
+            request_id=rid_bad,
+            lang="en",
+            json_payload=json.dumps(bad_summary),
+        )
+
+        rid_missing = self.db.create_request(
+            type_="url",
+            status="pending",
+            correlation_id="missing",
+            chat_id=1,
+            user_id=1,
+            input_url="https://example.com/missing",
+            normalized_url="https://example.com/missing",
+            route_version=1,
+        )
+
+        verification = self.db.verify_processing_integrity()
+
+        self.assertIn("overview", verification)
+        posts = verification.get("posts")
+        self.assertIsInstance(posts, dict)
+        self.assertEqual(posts.get("checked"), 3)
+        self.assertEqual(posts.get("with_summary"), 2)
+
+        missing_summary = posts.get("missing_summary") or []
+        self.assertEqual(len(missing_summary), 1)
+        self.assertEqual(missing_summary[0]["request_id"], rid_missing)
+
+        missing_fields = posts.get("missing_fields") or []
+        bad_entries = [entry for entry in missing_fields if entry.get("request_id") == rid_bad]
+        self.assertTrue(bad_entries)
+        bad_missing = bad_entries[0].get("missing") or []
+        self.assertIn("summary_250", bad_missing)
+        self.assertIn("summary_1000", bad_missing)
+        self.assertIn("metadata", bad_missing)
+
+        links_info = posts.get("links") or {}
+        self.assertEqual(links_info.get("total_links"), 1)
+        self.assertEqual(links_info.get("posts_with_links"), 1)
+        missing_links = links_info.get("missing_data") or []
+        self.assertTrue(any(entry.get("request_id") == rid_bad for entry in missing_links))
 
     def test_insert_telegram_message_handles_duplicate_request(self):
         rid = self.db.create_request(


### PR DESCRIPTION
## Summary
- add `Database.verify_processing_integrity` to audit stored summaries and link data
- expose a `/dbverify` command with a detailed verification reply and help text update
- cover the new verification flow with database- and command-level unit tests

## Testing
- `uv run ruff check . --fix`
- `uv run ruff format .`
- `uv run mypy .`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d40917946c832c9aa13bf45d3a390c