### PR TITLE
Add scheduled database backups

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -79,7 +79,7 @@ How to use (no commands needed)
    - `docker run --env-file .env -v $(pwd)/data:/data --name bsr --restart unless-stopped bite-size-reader`
 
 Notes
-- The SQLite DB lives at `/data/app.db` inside the container. Mount a host directory for persistence and backups.
+- The SQLite DB lives at `/data/app.db` inside the container. Mount a host directory for persistence and backups. The bot also writes timestamped snapshots under `/data/backups` (configurable via `DB_BACKUP_*` settings).
 - Ensure `ALLOWED_USER_IDS` is set to prevent unauthorized use.
 - Keep `DEBUG_PAYLOADS=0` in production.
 
@@ -109,7 +109,7 @@ Run: `docker compose up -d --build`
 ## Operations
 - Health: ensure the bot account stays unbanned and tokens valid.
 - Monitoring: watch logs for latency spikes and error rates; consider dashboarding via structured logs.
-- Backups: back up `data/app.db` periodically.
+- Backups: automatic snapshots land in `/data/backups`. Copy them off-host or adjust `DB_BACKUP_*` if you need a different cadence.
 
 ## Troubleshooting
 - “Access denied”: verify `ALLOWED_USER_IDS` contains your Telegram numeric ID.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Environment
 - `FIRECRAWL_API_KEY`
 - `OPENROUTER_API_KEY`, `OPENROUTER_MODEL`, `OPENROUTER_HTTP_REFERER`, `OPENROUTER_X_TITLE`
 - `DB_PATH=/data/app.db`, `LOG_LEVEL=INFO`, `REQUEST_TIMEOUT_SEC=60`
+- `DB_BACKUP_ENABLED=1`, `DB_BACKUP_INTERVAL_MINUTES=360`, `DB_BACKUP_RETENTION=14`, `DB_BACKUP_DIR=/data/backups`
 - `PREFERRED_LANG=auto` (auto|en|ru)
 - `DEBUG_PAYLOADS=0` — when `1`, logs request/response payload previews for Firecrawl/OpenRouter (with Authorization redacted)
  - `MAX_CONCURRENT_CALLS=4` — caps simultaneous Firecrawl/OpenRouter calls

--- a/tests/test_model_validation.py
+++ b/tests/test_model_validation.py
@@ -60,6 +60,32 @@ class TestModelValidation(unittest.TestCase):
             os.environ.clear()
             os.environ.update(old_env)
 
+    def test_load_config_backup_settings(self):
+        from app.config import load_config
+
+        old_env = os.environ.copy()
+        try:
+            os.environ["API_ID"] = "123456"
+            os.environ["API_HASH"] = "a" * 32
+            os.environ["BOT_TOKEN"] = "123456:abcdefghijklmnopqrstuvwxyz0123456789abcdefghij"
+            os.environ["FIRECRAWL_API_KEY"] = "fc_" + "d" * 20
+            os.environ["OPENROUTER_API_KEY"] = "or_" + "e" * 20
+            os.environ["ALLOWED_USER_IDS"] = "42"
+            os.environ["DB_BACKUP_ENABLED"] = "0"
+            os.environ["DB_BACKUP_INTERVAL_MINUTES"] = "45"
+            os.environ["DB_BACKUP_RETENTION"] = "5"
+            os.environ["DB_BACKUP_DIR"] = "/tmp/backups"
+
+            cfg = load_config()
+
+            self.assertFalse(cfg.runtime.db_backup_enabled)
+            self.assertEqual(cfg.runtime.db_backup_interval_minutes, 45)
+            self.assertEqual(cfg.runtime.db_backup_retention, 5)
+            self.assertEqual(cfg.runtime.db_backup_dir, "/tmp/backups")
+        finally:
+            os.environ.clear()
+            os.environ.update(old_env)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add runtime configuration options and helper functions for database backups
- schedule periodic database snapshots from the Telegram bot and prune old copies
- cover the backup flow with tests and document the new environment settings

## Testing
- uv run ruff check . --fix
- uv run ruff format .
- uv run mypy .
- uv run python -m unittest discover -s tests -p "test_*.py" -v

------
https://chatgpt.com/codex/tasks/task_e_68d418193304832c903c9c45caef2b80