### PR TITLE
Handle low-value Firecrawl results

### DIFF
--- a/app/adapters/content/content_extractor.py
+++ b/app/adapters/content/content_extractor.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import json
 import logging
+import re
+from collections import Counter
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
@@ -265,6 +267,58 @@ class ContentExtractor:
         async with self._sem():
             crawl = await self.firecrawl.scrape_markdown(url_text, request_id=req_id)
 
+        quality_issue = self._detect_low_value_content(crawl)
+        if quality_issue:
+            metrics = quality_issue["metrics"]
+            reason_label = quality_issue["reason"]
+            metric_str = (
+                f"chars={metrics['char_length']}, words={metrics['word_count']}, "
+                f"unique={metrics['unique_word_count']}"
+            )
+            if metrics.get("top_word"):
+                metric_str += (
+                    f", top_word={metrics['top_word']}, top_ratio={metrics['top_ratio']:.2f}"
+                )
+            if metrics.get("overlay_ratio") is not None:
+                metric_str += f", overlay_ratio={metrics['overlay_ratio']:.2f}"
+
+            crawl.status = "error"
+            crawl.error_text = f"insufficient_useful_content:{reason_label} ({metric_str})"
+
+            if self._audit:
+                try:
+                    audit_payload = {
+                        "request_id": req_id,
+                        "cid": correlation_id,
+                        "reason": reason_label,
+                        "char_length": metrics["char_length"],
+                        "word_count": metrics["word_count"],
+                        "unique_word_count": metrics["unique_word_count"],
+                    }
+                    if metrics.get("top_word"):
+                        audit_payload["top_word"] = metrics["top_word"]
+                        audit_payload["top_ratio"] = round(metrics["top_ratio"], 3)
+                    if metrics.get("overlay_ratio") is not None:
+                        audit_payload["overlay_ratio"] = round(metrics["overlay_ratio"], 3)
+                    self._audit("WARNING", "firecrawl_low_value_content", audit_payload)
+                except Exception:
+                    pass
+
+            logger.warning(
+                "firecrawl_low_value_content",
+                extra={
+                    "cid": correlation_id,
+                    "reason": reason_label,
+                    "char_length": metrics["char_length"],
+                    "word_count": metrics["word_count"],
+                    "unique_word_count": metrics["unique_word_count"],
+                    "top_word": metrics.get("top_word"),
+                    "top_ratio": metrics.get("top_ratio"),
+                    "overlay_ratio": metrics.get("overlay_ratio"),
+                    "preview": quality_issue.get("preview"),
+                },
+            )
+
         # Persist crawl result
         try:
             self.db.insert_crawl_result(
@@ -306,6 +360,10 @@ class ContentExtractor:
         # Validate crawl result
         has_markdown = bool(crawl.content_markdown and crawl.content_markdown.strip())
         has_html = bool(crawl.content_html and crawl.content_html.strip())
+
+        if quality_issue:
+            has_markdown = False
+            has_html = False
 
         if crawl.status != "ok" or not (has_markdown or has_html):
             # Attempt a direct HTML fetch salvage before failing
@@ -389,10 +447,82 @@ class ContentExtractor:
                 has_html,
                 silent,
             )
-            raise ValueError("Firecrawl extraction failed")
+            failure_reason = crawl.error_text or "Firecrawl extraction failed"
+            raise ValueError(f"Firecrawl extraction failed: {failure_reason}")
 
         # Process successful crawl
         return await self._process_successful_crawl(message, crawl, correlation_id, silent)
+
+    def _detect_low_value_content(self, crawl: FirecrawlResult) -> dict[str, Any] | None:
+        """Detect low-value Firecrawl responses that should halt processing."""
+
+        text_candidates: list[str] = []
+        if crawl.content_markdown and crawl.content_markdown.strip():
+            text_candidates.append(clean_markdown_article_text(crawl.content_markdown))
+        if crawl.content_html and crawl.content_html.strip():
+            text_candidates.append(html_to_text(crawl.content_html))
+
+        primary_text = next((t for t in text_candidates if t and t.strip()), "")
+        normalized = re.sub(r"\s+", " ", primary_text).strip()
+
+        words_raw = re.findall(r"[0-9A-Za-zÀ-ÖØ-öø-ÿ']+", normalized)
+        words = [w.lower() for w in words_raw if w]
+        word_count = len(words)
+        unique_word_count = len(set(words))
+
+        top_word: str | None = None
+        top_ratio = 0.0
+        if words:
+            counter = Counter(words)
+            top_word, top_count = counter.most_common(1)[0]
+            top_ratio = top_count / word_count if word_count else 0.0
+
+        overlay_terms = {
+            "accept",
+            "close",
+            "cookie",
+            "cookies",
+            "consent",
+            "login",
+            "signin",
+            "signup",
+            "subscribe",
+        }
+        overlay_hits = sum(1 for w in words if w in overlay_terms)
+        overlay_ratio = overlay_hits / word_count if word_count else 0.0
+
+        metrics: dict[str, Any] = {
+            "char_length": len(normalized),
+            "word_count": word_count,
+            "unique_word_count": unique_word_count,
+            "top_word": top_word,
+            "top_ratio": top_ratio,
+            "overlay_ratio": overlay_ratio,
+        }
+
+        reason: str | None = None
+        if not normalized or word_count == 0:
+            reason = "empty_after_cleaning"
+        elif overlay_ratio >= 0.7 and len(normalized) < 600:
+            reason = "overlay_content_detected"
+        elif len(normalized) < 48 and word_count <= 2:
+            reason = "content_too_short"
+        elif len(normalized) < 120 and (
+            unique_word_count <= 3 or (word_count >= 4 and top_ratio >= 0.8)
+        ):
+            reason = "content_low_variation"
+        elif word_count >= 6 and top_ratio >= 0.92:
+            reason = "content_high_repetition"
+
+        if reason:
+            preview = normalized[:200]
+            return {
+                "reason": reason,
+                "metrics": metrics,
+                "preview": preview,
+            }
+
+        return None
 
     async def _handle_crawl_error(
         self,

--- a/app/adapters/content/content_extractor.py
+++ b/app/adapters/content/content_extractor.py
@@ -9,7 +9,8 @@ import logging
 import re
 from collections import Counter
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING, Any, Literal
 
 import httpx
 
@@ -34,6 +35,35 @@ logger = logging.getLogger(__name__)
 
 # Route versioning constants
 URL_ROUTE_VERSION = 1
+
+LowValueReason = Literal[
+    "empty_after_cleaning",
+    "overlay_content_detected",
+    "content_too_short",
+    "content_low_variation",
+    "content_high_repetition",
+]
+
+
+@dataclass(slots=True)
+class LowValueContentMetrics:
+    """Simple container describing crawl content quality metrics."""
+
+    char_length: int
+    word_count: int
+    unique_word_count: int
+    top_word: str | None
+    top_ratio: float
+    overlay_ratio: float
+
+
+@dataclass(slots=True)
+class LowValueContentIssue:
+    """Metadata about low-value crawl content returned by Firecrawl."""
+
+    reason: LowValueReason
+    metrics: LowValueContentMetrics
+    preview: str
 
 
 class ContentExtractor:
@@ -269,18 +299,19 @@ class ContentExtractor:
 
         quality_issue = self._detect_low_value_content(crawl)
         if quality_issue:
-            metrics = quality_issue["metrics"]
-            reason_label = quality_issue["reason"]
-            metric_str = (
-                f"chars={metrics['char_length']}, words={metrics['word_count']}, "
-                f"unique={metrics['unique_word_count']}"
-            )
-            if metrics.get("top_word"):
-                metric_str += (
-                    f", top_word={metrics['top_word']}, top_ratio={metrics['top_ratio']:.2f}"
+            metrics = quality_issue.metrics
+            reason_label = quality_issue.reason
+            metric_parts = [
+                f"chars={metrics.char_length}",
+                f"words={metrics.word_count}",
+                f"unique={metrics.unique_word_count}",
+            ]
+            if metrics.top_word:
+                metric_parts.append(
+                    f"top_word={metrics.top_word}, top_ratio={metrics.top_ratio:.2f}"
                 )
-            if metrics.get("overlay_ratio") is not None:
-                metric_str += f", overlay_ratio={metrics['overlay_ratio']:.2f}"
+            metric_parts.append(f"overlay_ratio={metrics.overlay_ratio:.2f}")
+            metric_str = ", ".join(metric_parts)
 
             crawl.status = "error"
             crawl.error_text = f"insufficient_useful_content:{reason_label} ({metric_str})"
@@ -291,15 +322,14 @@ class ContentExtractor:
                         "request_id": req_id,
                         "cid": correlation_id,
                         "reason": reason_label,
-                        "char_length": metrics["char_length"],
-                        "word_count": metrics["word_count"],
-                        "unique_word_count": metrics["unique_word_count"],
+                        "char_length": metrics.char_length,
+                        "word_count": metrics.word_count,
+                        "unique_word_count": metrics.unique_word_count,
+                        "overlay_ratio": round(metrics.overlay_ratio, 3),
                     }
-                    if metrics.get("top_word"):
-                        audit_payload["top_word"] = metrics["top_word"]
-                        audit_payload["top_ratio"] = round(metrics["top_ratio"], 3)
-                    if metrics.get("overlay_ratio") is not None:
-                        audit_payload["overlay_ratio"] = round(metrics["overlay_ratio"], 3)
+                    if metrics.top_word:
+                        audit_payload["top_word"] = metrics.top_word
+                        audit_payload["top_ratio"] = round(metrics.top_ratio, 3)
                     self._audit("WARNING", "firecrawl_low_value_content", audit_payload)
                 except Exception:
                     pass
@@ -309,13 +339,8 @@ class ContentExtractor:
                 extra={
                     "cid": correlation_id,
                     "reason": reason_label,
-                    "char_length": metrics["char_length"],
-                    "word_count": metrics["word_count"],
-                    "unique_word_count": metrics["unique_word_count"],
-                    "top_word": metrics.get("top_word"),
-                    "top_ratio": metrics.get("top_ratio"),
-                    "overlay_ratio": metrics.get("overlay_ratio"),
-                    "preview": quality_issue.get("preview"),
+                    **asdict(metrics),
+                    "preview": quality_issue.preview,
                 },
             )
 
@@ -453,7 +478,7 @@ class ContentExtractor:
         # Process successful crawl
         return await self._process_successful_crawl(message, crawl, correlation_id, silent)
 
-    def _detect_low_value_content(self, crawl: FirecrawlResult) -> dict[str, Any] | None:
+    def _detect_low_value_content(self, crawl: FirecrawlResult) -> LowValueContentIssue | None:
         """Detect low-value Firecrawl responses that should halt processing."""
 
         text_candidates: list[str] = []
@@ -491,16 +516,16 @@ class ContentExtractor:
         overlay_hits = sum(1 for w in words if w in overlay_terms)
         overlay_ratio = overlay_hits / word_count if word_count else 0.0
 
-        metrics: dict[str, Any] = {
-            "char_length": len(normalized),
-            "word_count": word_count,
-            "unique_word_count": unique_word_count,
-            "top_word": top_word,
-            "top_ratio": top_ratio,
-            "overlay_ratio": overlay_ratio,
-        }
+        metrics = LowValueContentMetrics(
+            char_length=len(normalized),
+            word_count=word_count,
+            unique_word_count=unique_word_count,
+            top_word=top_word,
+            top_ratio=top_ratio,
+            overlay_ratio=overlay_ratio,
+        )
 
-        reason: str | None = None
+        reason: LowValueReason | None = None
         if not normalized or word_count == 0:
             reason = "empty_after_cleaning"
         elif overlay_ratio >= 0.7 and len(normalized) < 600:
@@ -516,11 +541,7 @@ class ContentExtractor:
 
         if reason:
             preview = normalized[:200]
-            return {
-                "reason": reason,
-                "metrics": metrics,
-                "preview": preview,
-            }
+            return LowValueContentIssue(reason=reason, metrics=metrics, preview=preview)
 
         return None
 

--- a/tests/test_content_quality.py
+++ b/tests/test_content_quality.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.adapters.content.content_extractor import ContentExtractor
+from app.adapters.external.firecrawl_parser import FirecrawlResult
+from app.config import AppConfig
+
+
+@asynccontextmanager
+async def _dummy_sem() -> AsyncIterator[None]:
+    yield
+
+
+def _make_extractor(
+    db: MagicMock, response_formatter: MagicMock, firecrawl: MagicMock
+) -> ContentExtractor:
+    cfg = cast(
+        AppConfig,
+        SimpleNamespace(runtime=SimpleNamespace(enable_textacy=False, request_timeout_sec=5)),
+    )
+    return ContentExtractor(
+        cfg=cfg,
+        db=db,
+        firecrawl=firecrawl,
+        response_formatter=response_formatter,
+        audit_func=lambda *args, **kwargs: None,
+        sem=_dummy_sem,
+    )
+
+
+def _firecrawl_result(markdown: str | None, html: str | None) -> FirecrawlResult:
+    return FirecrawlResult(
+        status="ok",
+        http_status=200,
+        content_markdown=markdown,
+        content_html=html,
+        structured_json=None,
+        metadata_json=None,
+        links_json=None,
+        raw_response_json={"markdown": markdown, "html": html},
+        latency_ms=123,
+        error_text=None,
+        source_url="https://example.com",
+        endpoint="/v1/scrape",
+        options_json={"formats": ["markdown", "html"]},
+        correlation_id="cid-123",
+    )
+
+
+@pytest.mark.asyncio
+async def test_low_value_content_triggers_failure() -> None:
+    db = MagicMock()
+    response_formatter = MagicMock()
+    response_formatter.send_firecrawl_start_notification = AsyncMock()
+    response_formatter.send_error_notification = AsyncMock()
+    response_formatter.send_html_fallback_notification = AsyncMock()
+    response_formatter.send_firecrawl_success_notification = AsyncMock()
+
+    firecrawl = MagicMock()
+    firecrawl.scrape_markdown = AsyncMock(
+        return_value=_firecrawl_result(markdown="Close Close", html="<p>Close</p>")
+    )
+
+    extractor = _make_extractor(db, response_formatter, firecrawl)
+    cast(Any, extractor)._attempt_direct_html_salvage = AsyncMock(return_value=None)
+
+    with pytest.raises(ValueError) as exc_info:
+        await extractor._perform_new_crawl(
+            message=SimpleNamespace(),
+            req_id=42,
+            url_text="https://example.com",
+            correlation_id="cid-123",
+            interaction_id=None,
+            silent=False,
+        )
+
+    assert "insufficient_useful_content" in str(exc_info.value)
+    db.update_request_status.assert_called_with(42, "error")
+    response_formatter.send_error_notification.assert_awaited()
+    response_formatter.send_firecrawl_success_notification.assert_not_awaited()
+
+    assert db.insert_crawl_result.called
+    inserted_kwargs = db.insert_crawl_result.call_args.kwargs
+    assert inserted_kwargs["status"] == "error"
+    assert "insufficient_useful_content" in inserted_kwargs["error_text"]
+
+
+def test_detect_low_value_content_allows_substantive_text() -> None:
+    db = MagicMock()
+    response_formatter = MagicMock()
+    firecrawl = MagicMock()
+
+    extractor = _make_extractor(db, response_formatter, firecrawl)
+
+    result = _firecrawl_result(
+        markdown="# Heading\n\nThis short article explains the basics of Obsidian vault design.",
+        html=None,
+    )
+
+    assert extractor._detect_low_value_content(result) is None


### PR DESCRIPTION
## Summary
- detect low-value Firecrawl responses and surface them as errors before continuing the URL flow
- log and audit the new failure mode, preventing summarization when Firecrawl returns only repetitive overlay text
- add regression tests covering low-value detection while allowing substantive content to pass through

## Testing
- uv run ruff check . --fix
- uv run ruff format .
- uv run mypy .
- uv run pytest tests/test_content_quality.py


------
https://chatgpt.com/codex/tasks/task_e_68d50f377314832ca60d9b8d2f816780