### PR TITLE
Remove enhanced wording from user-facing messages

### DIFF
--- a/app/adapters/content/content_chunker.py
+++ b/app/adapters/content/content_chunker.py
@@ -137,7 +137,7 @@ class ContentChunker:
                 },
             ]
             async with self._sem():
-                # Use enhanced structured output format
+                # Use structured output format
                 response_format_cf = self._build_structured_response_format()
                 # Use dynamic token budget based on chunk size
                 chunk_tokens = max(1024, min(4096, len(chunk) // 4 + 1024))

--- a/app/adapters/content/llm_summarizer.py
+++ b/app/adapters/content/llm_summarizer.py
@@ -139,7 +139,7 @@ class LLMSummarizer:
             {"role": "user", "content": user_content},
         ]
 
-        # Notify: Starting enhanced LLM call
+        # Notify: Starting LLM call
         await self.response_formatter.send_llm_start_notification(
             message,
             self.cfg.openrouter.model,
@@ -155,7 +155,7 @@ class LLMSummarizer:
             model_override = self.cfg.openrouter.long_context_model
 
         async with self._sem():
-            # Use enhanced structured output configuration
+            # Use structured output configuration
             response_format = self._build_structured_response_format()
             max_tokens = self._select_max_tokens(content_text)
             self._last_llm_result = None
@@ -173,7 +173,7 @@ class LLMSummarizer:
 
             self._last_llm_result = llm
 
-        # Enhanced LLM completion notification
+        # LLM completion notification
         await self.response_formatter.send_llm_completion_notification(
             message, llm, correlation_id, silent=silent
         )
@@ -613,7 +613,7 @@ class LLMSummarizer:
         silent: bool = False,
     ) -> dict[str, Any] | None:
         """Process LLM response and handle errors/repairs."""
-        # Enhanced error handling and salvage logic
+        # Robust error handling and salvage logic
         salvage_shaped: dict[str, Any] | None = None
         if llm.status != "ok" and (llm.error_text or "") == "structured_output_parse_error":
             salvage_shaped = await self._attempt_salvage_parsing(llm, correlation_id)
@@ -627,7 +627,7 @@ class LLMSummarizer:
                 await self._handle_llm_error(message, llm, req_id, correlation_id, interaction_id)
                 return None
 
-        # Enhanced parsing with better error handling
+        # Parsing with better error handling
         summary_shaped: dict[str, Any] | None = salvage_shaped
 
         if summary_shaped is None:
@@ -1097,9 +1097,11 @@ class LLMSummarizer:
                 error_text=llm.error_text,
                 structured_output_used=getattr(llm, "structured_output_used", None),
                 structured_output_mode=getattr(llm, "structured_output_mode", None),
-                error_context_json=json.dumps(getattr(llm, "error_context", {}) or {}, default=str)
-                if getattr(llm, "error_context", None) is not None
-                else None,
+                error_context_json=(
+                    json.dumps(getattr(llm, "error_context", {}) or {}, default=str)
+                    if getattr(llm, "error_context", None) is not None
+                    else None
+                ),
             )
         except Exception as e:  # noqa: BLE001
             logger.error("persist_llm_error", extra={"error": str(e), "cid": correlation_id})
@@ -1220,7 +1222,7 @@ class LLMSummarizer:
         if not should_attempt_repair:
             return shaped
 
-        # Enhanced repair logic with structured outputs
+        # Repair logic with structured outputs
         repaired = await self._attempt_json_repair(
             message,
             llm,
@@ -1361,9 +1363,9 @@ class LLMSummarizer:
                 "json_repair_attempt_enhanced",
                 extra={
                     "cid": correlation_id,
-                    "reason": parse_result.errors[-3:]
-                    if parse_result and parse_result.errors
-                    else None,
+                    "reason": (
+                        parse_result.errors[-3:] if parse_result and parse_result.errors else None
+                    ),
                     "structured_mode": self.cfg.openrouter.structured_output_mode,
                 },
             )

--- a/app/adapters/content/url_processor.py
+++ b/app/adapters/content/url_processor.py
@@ -1,4 +1,5 @@
 """Refactored URL processor using modular components."""
+
 # ruff: noqa: E501
 # flake8: noqa
 
@@ -239,7 +240,7 @@ class URLProcessor:
 
                 # Skip Telegram responses if silent
                 if not silent:
-                    await self.response_formatter.send_enhanced_summary_response(
+                    await self.response_formatter.send_structured_summary_response(
                         message,
                         shaped,
                         llm_result,
@@ -375,9 +376,9 @@ class URLProcessor:
                 request_id=req_id,
             )
 
-        # Send enhanced results (skip if silent)
+        # Send structured results (skip if silent)
         if not silent:
-            await self.response_formatter.send_enhanced_summary_response(
+            await self.response_formatter.send_structured_summary_response(
                 message, shaped, llm, chunks=chunk_count
             )
             logger.info("reply_json_sent", extra={"cid": correlation_id, "request_id": req_id})
@@ -598,7 +599,9 @@ class URLProcessor:
             except Exception:
                 model_name = None
             llm_stub = type("LLMStub", (), {"model": model_name})()
-            await self.response_formatter.send_enhanced_summary_response(message, shaped, llm_stub)
+            await self.response_formatter.send_structured_summary_response(
+                message, shaped, llm_stub
+            )
 
             insights_raw = summary_row.get("insights_json")
             if isinstance(insights_raw, str) and insights_raw.strip():

--- a/app/adapters/external/response_formatter.py
+++ b/app/adapters/external/response_formatter.py
@@ -186,7 +186,7 @@ class ResponseFormatter:
             "• Multiple links in one message are supported\n"
             "• Use `/unread` to see your saved articles\n\n"
             "⚡ **Features:**\n"
-            "• Enhanced structured JSON output with schema validation\n"
+            "• Structured JSON output with schema validation\n"
             "• Intelligent model fallbacks for better reliability\n"
             "• Automatic content optimization based on model capabilities\n"
             "• Silent batch processing for uploaded files\n"
@@ -201,7 +201,7 @@ class ResponseFormatter:
             "What I do:\n"
             "- Summarize articles from URLs using Firecrawl + OpenRouter.\n"
             "- Summarize forwarded channel posts.\n"
-            "- Generate structured JSON summaries with enhanced reliability.\n\n"
+            "- Generate structured JSON summaries with reliable results.\n\n"
             "How to use:\n"
             "- Send a URL directly, or use /summarize <URL>.\n"
             "- You can also send /summarize and then the URL in the next message.\n"
@@ -481,10 +481,10 @@ class ResponseFormatter:
 
         await self.safe_reply(message, "\n".join(lines))
 
-    async def send_enhanced_summary_response(
+    async def send_structured_summary_response(
         self, message: Any, summary_shaped: dict[str, Any], llm: Any, chunks: int | None = None
     ) -> None:
-        """Send enhanced summary where each top-level JSON field is a separate message,
+        """Send summary where each top-level JSON field is a separate message,
         then attach the full JSON as a .json document with a descriptive filename."""
         try:
             # Optional short header
@@ -1185,9 +1185,9 @@ class ResponseFormatter:
                     "chat_id": chat_id,
                     "message_id": message_id,
                     "has_telegram_client": self._telegram_client is not None,
-                    "telegram_client_has_client": hasattr(self._telegram_client, "client")
-                    if self._telegram_client
-                    else False,
+                    "telegram_client_has_client": (
+                        hasattr(self._telegram_client, "client") if self._telegram_client else False
+                    ),
                     "client": self._telegram_client.client if self._telegram_client else None,
                 },
             )
@@ -1247,7 +1247,7 @@ class ResponseFormatter:
                 f"🌐 Domain: `{url_domain}`\n"
                 f"🔗 URL: `{norm[:60]}{'...' if len(norm) > 60 else ''}`\n"
                 f"📋 Status: Fetching content...\n"
-                f"🤖 Enhanced: Structured output with smart fallbacks",
+                f"🤖 Structured output with smart fallbacks",
             )
         except Exception:
             pass
@@ -1496,7 +1496,7 @@ class ResponseFormatter:
                 "🕷️ **Firecrawl Extraction**\n"
                 "📡 Connecting to Firecrawl API...\n"
                 "⏱️ This may take 10-30 seconds\n"
-                "🔄 Enhanced processing pipeline active",
+                "🔄 Processing pipeline active",
             )
         except Exception:
             pass
@@ -1543,7 +1543,7 @@ class ResponseFormatter:
             if correlation_id:
                 lines.append(f"🆔 Firecrawl CID: `{correlation_id}`")
 
-            lines.append("🔄 Status: Preparing for enhanced AI analysis...")
+            lines.append("🔄 Status: Preparing for AI analysis...")
 
             await self.safe_reply(message, "\n".join(lines))
         except Exception:
@@ -1587,7 +1587,7 @@ class ResponseFormatter:
             if correlation_id:
                 lines.append(f"🆔 Firecrawl CID: `{correlation_id}`")
 
-            lines.append("⚡ Proceeding to enhanced AI analysis...")
+            lines.append("⚡ Proceeding to AI analysis...")
 
             await self.safe_reply(message, "\n".join(lines))
         except Exception:
@@ -1618,7 +1618,7 @@ class ResponseFormatter:
                 f"📄 Markdown extraction was empty\n"
                 f"🛠️ Using HTML content extraction\n"
                 f"📊 Processing {content_len:,} characters...\n"
-                f"🤖 Enhanced pipeline will optimize for best results",
+                f"🤖 Pipeline will optimize for best results",
             )
         except Exception:
             pass
@@ -1636,7 +1636,7 @@ class ResponseFormatter:
                 f"📝 Detected: `{detected or 'unknown'}`\n"
                 f"📄 Content preview:\n"
                 f"```\n{content_preview}\n```\n"
-                f"🤖 Status: Preparing enhanced AI analysis with structured outputs...",
+                f"🤖 Status: Preparing AI analysis with structured outputs...",
             )
         except Exception:
             pass
@@ -1659,7 +1659,7 @@ class ResponseFormatter:
             if enable_chunking and content_len > max_chars and (chunks or []):
                 await self.safe_reply(
                     message,
-                    f"📚 **Enhanced Content Analysis**\n"
+                    f"📚 **Content Analysis**\n"
                     f"📊 Length: {content_len:,} characters\n"
                     f"🔀 Processing: Chunked analysis ({len(chunks or [])} chunks)\n"
                     f"🤖 Method: Advanced structured output with schema validation\n"
@@ -1668,16 +1668,16 @@ class ResponseFormatter:
             elif not enable_chunking and content_len > max_chars:
                 await self.safe_reply(
                     message,
-                    f"📚 **Enhanced Content Analysis**\n"
+                    f"📚 **Content Analysis**\n"
                     f"📊 Length: {content_len:,} characters (exceeds {max_chars:,} adaptive threshold)\n"
                     f"🔀 Processing: Single-pass (chunking disabled)\n"
-                    f"🤖 Method: Enhanced structured output with intelligent fallbacks\n"
+                    f"🤖 Method: Structured output with intelligent fallbacks\n"
                     f"⚡ Status: Sending to AI model...",
                 )
             else:
                 await self.safe_reply(
                     message,
-                    f"📚 **Enhanced Content Analysis**\n"
+                    f"📚 **Content Analysis**\n"
                     f"📊 Length: {content_len:,} characters\n"
                     f"🔀 Processing: Single-pass summary\n"
                     f"🤖 Method: Structured output with schema validation\n"
@@ -1702,7 +1702,7 @@ class ResponseFormatter:
         try:
             await self.safe_reply(
                 message,
-                f"🤖 **Enhanced AI Analysis Starting**\n"
+                f"🤖 **AI Analysis Starting**\n"
                 f"🧠 Model: `{model}`\n"
                 f"📊 Content: {content_len:,} characters\n"
                 f"🔧 Mode: {structured_output_mode.upper()} with smart fallbacks\n"
@@ -1727,7 +1727,7 @@ class ResponseFormatter:
                 tokens_used = prompt_tokens + completion_tokens
 
                 lines = [
-                    "🤖 **Enhanced AI Analysis Complete**",
+                    "🤖 **AI Analysis Complete**",
                     "✅ Status: Success",
                     f"🧠 Model: `{model_name}`",
                     f"⏱️ Processing time: {latency_sec:.1f}s",
@@ -1751,14 +1751,14 @@ class ResponseFormatter:
                 if correlation_id:
                     lines.append(f"🆔 Request ID: `{correlation_id}`")
 
-                lines.append("📋 Status: Generating enhanced summary...")
+                lines.append("📋 Status: Generating summary...")
 
                 await self.safe_reply(message, "\n".join(lines))
             else:
-                # Enhanced error message
+                # Error message for failure scenarios
                 await self.safe_reply(
                     message,
-                    f"🤖 **Enhanced AI Analysis Failed**\n"
+                    f"🤖 **AI Analysis Failed**\n"
                     f"❌ Status: Error\n"
                     f"🧠 Model: `{model_name}`\n"
                     f"⏱️ Processing time: {latency_sec:.1f}s\n"
@@ -1819,7 +1819,7 @@ class ResponseFormatter:
                 message,
                 "✅ **Forward Request Accepted**\n"
                 f"📺 Channel: {title}\n"
-                "🤖 Enhanced processing with structured outputs...\n"
+                "🤖 Processing with structured outputs...\n"
                 "📋 Status: Generating summary...",
             )
         except Exception:
@@ -1832,7 +1832,7 @@ class ResponseFormatter:
                 message,
                 f"🌍 **Language Detection**\n"
                 f"📝 Detected: `{detected or 'unknown'}`\n"
-                f"🤖 Processing with enhanced structured outputs...\n"
+                f"🤖 Processing with structured outputs...\n"
                 f"⚡ Status: Sending to AI model...",
             )
         except Exception:
@@ -1850,7 +1850,7 @@ class ResponseFormatter:
 
             await self.safe_reply(
                 message,
-                f"🤖 **Enhanced AI Analysis Complete**\n"
+                f"🤖 **AI Analysis Complete**\n"
                 f"{status_emoji} Status: {'Success' if llm.status == 'ok' else 'Error'}\n"
                 f"⏱️ Time: {latency_sec:.1f}s{structured_info}\n"
                 f"📋 Status: {'Generating summary...' if llm.status == 'ok' else 'Processing error...'}",
@@ -1865,7 +1865,7 @@ class ResponseFormatter:
         correlation_id: str,
         details: str | None = None,
     ) -> None:
-        """Send error notification with enhanced formatting."""
+        """Send error notification with rich formatting."""
         try:
             if error_type == "firecrawl_error":
                 details_block = f"\n\n{details}" if details else ""
@@ -1908,7 +1908,7 @@ class ResponseFormatter:
                 else:
                     await self.safe_reply(
                         message,
-                        f"❌ **Enhanced Processing Failed**\n"
+                        f"❌ **Processing Failed**\n"
                         f"🚨 Invalid summary format despite smart fallbacks{detail_block}\n"
                         f"🆔 Error ID: `{correlation_id}`",
                     )
@@ -1916,7 +1916,7 @@ class ResponseFormatter:
                 detail_block = f"\n🔍 Provider response: {details}" if details else ""
                 await self.safe_reply(
                     message,
-                    f"❌ **Enhanced Processing Failed**\n"
+                    f"❌ **Processing Failed**\n"
                     f"🚨 LLM error despite smart fallbacks{detail_block}\n"
                     f"🆔 Error ID: `{correlation_id}`",
                 )

--- a/app/adapters/telegram/command_processor.py
+++ b/app/adapters/telegram/command_processor.py
@@ -1,4 +1,5 @@
 """Command processing for Telegram bot."""
+
 # ruff: noqa: E501
 # flake8: noqa
 
@@ -610,7 +611,7 @@ class CommandProcessor:
                 except Exception:
                     model_name = None
                 llm_stub = type("LLMStub", (), {"model": model_name})()
-                await self.response_formatter.send_enhanced_summary_response(
+                await self.response_formatter.send_structured_summary_response(
                     message, shaped, llm_stub
                 )
 

--- a/app/adapters/telegram/forward_processor.py
+++ b/app/adapters/telegram/forward_processor.py
@@ -80,7 +80,7 @@ class ForwardProcessor:
             )
 
             if forward_shaped:
-                # Send enhanced preview for forward flow
+                # Send formatted preview for forward flow
                 await self.response_formatter.send_forward_summary_response(message, forward_shaped)
 
                 # Generate and send additional research insights (same as URL processing)

--- a/app/adapters/telegram/forward_summarizer.py
+++ b/app/adapters/telegram/forward_summarizer.py
@@ -76,7 +76,7 @@ class ForwardSummarizer:
         ]
 
         async with self._sem():
-            # Use enhanced structured output configuration for forwarded messages
+            # Use structured output configuration for forwarded messages
             fwd_response_format = self._build_structured_response_format()
 
             # Use dynamic token budget based on content length
@@ -90,7 +90,7 @@ class ForwardSummarizer:
                 response_format=fwd_response_format,
             )
 
-        # Enhanced notification for forward completion
+        # Notification for forward completion
         await self.response_formatter.send_forward_completion_notification(message, llm)
 
         # Process response
@@ -109,7 +109,7 @@ class ForwardSummarizer:
         interaction_id: int | None,
     ) -> dict[str, Any] | None:
         """Process forward LLM response."""
-        # Enhanced salvage logic for forward flow
+        # Salvage logic for forward flow
         forward_salvage_shaped: dict[str, Any] | None = None
         if llm.status != "ok" and (llm.error_text or "") == "structured_output_parse_error":
             forward_salvage_shaped = await self._attempt_salvage_parsing(llm, correlation_id)
@@ -118,7 +118,7 @@ class ForwardSummarizer:
             await self._handle_llm_error(message, llm, req_id, correlation_id, interaction_id)
             return None
 
-        # Enhanced parsing for forward flow
+        # Parsing for forward flow
         forward_shaped: dict[str, Any] | None = forward_salvage_shaped
 
         if forward_shaped is None:
@@ -191,9 +191,11 @@ class ForwardSummarizer:
                 error_text=llm.error_text,
                 structured_output_used=getattr(llm, "structured_output_used", None),
                 structured_output_mode=getattr(llm, "structured_output_mode", None),
-                error_context_json=json.dumps(getattr(llm, "error_context", {}) or {}, default=str)
-                if getattr(llm, "error_context", None) is not None
-                else None,
+                error_context_json=(
+                    json.dumps(getattr(llm, "error_context", {}) or {}, default=str)
+                    if getattr(llm, "error_context", None) is not None
+                    else None
+                ),
             )
         except Exception as e:  # noqa: BLE001
             logger.error("persist_llm_error", extra={"error": str(e), "cid": correlation_id})
@@ -248,7 +250,7 @@ class ForwardSummarizer:
                 )
             return parse_result.shaped
         else:
-            # Enhanced repair for forward flow
+            # Repair for forward flow
             return await self._attempt_json_repair(
                 message, llm, messages, req_id, correlation_id, interaction_id
             )
@@ -391,9 +393,11 @@ class ForwardSummarizer:
                 error_text=llm.error_text,
                 structured_output_used=getattr(llm, "structured_output_used", None),
                 structured_output_mode=getattr(llm, "structured_output_mode", None),
-                error_context_json=json.dumps(getattr(llm, "error_context", {}) or {}, default=str)
-                if getattr(llm, "error_context", None) is not None
-                else None,
+                error_context_json=(
+                    json.dumps(getattr(llm, "error_context", {}) or {}, default=str)
+                    if getattr(llm, "error_context", None) is not None
+                    else None
+                ),
             )
         except Exception as e:  # noqa: BLE001
             logger.error("persist_llm_error", extra={"error": str(e), "cid": correlation_id})

--- a/app/adapters/telegram/telegram_client.py
+++ b/app/adapters/telegram/telegram_client.py
@@ -114,11 +114,11 @@ class TelegramClient:
                 # Optional descriptions (if supported)
                 try:
                     await client_any.set_bot_description(
-                        "Summarize URLs and forwarded posts into structured JSON with enhanced reliability.",
+                        "Summarize URLs and forwarded posts into structured JSON with reliable results.",
                         language_code="en",
                     )
                     await client_any.set_bot_short_description(
-                        "Enhanced JSON summaries with smart fallbacks", language_code="en"
+                        "Structured JSON summaries with smart fallbacks", language_code="en"
                     )
                     await client_any.set_bot_description(
                         "Улучшенные резюме ссылок и пересланных постов в формате JSON с повышенной надёжностью.",


### PR DESCRIPTION
## Summary
- replace “enhanced” phrasing in user-facing Telegram notifications with neutral wording
- rename the response formatter helper to `send_structured_summary_response` and update call sites
- refresh bot descriptions and related comments to match the new terminology

## Testing
- ruff check . --fix
- ruff format .
- mypy .

------
https://chatgpt.com/codex/tasks/task_e_68d8e89baa44832ca8b01dcad47f10f0