### PR TITLE
Improve summary insights handling and token budgets

### DIFF
--- a/app/adapters/content/url_processor.py
+++ b/app/adapters/content/url_processor.py
@@ -213,6 +213,7 @@ class URLProcessor:
                         chosen_lang,
                         req_id,
                         correlation_id,
+                        summary=shaped,
                         silent=silent,
                     )
                     return
@@ -264,6 +265,7 @@ class URLProcessor:
                         chosen_lang,
                         req_id,
                         correlation_id,
+                        summary=shaped,
                     )
 
                     # Generate a standalone custom article based on extracted topics/tags
@@ -310,6 +312,7 @@ class URLProcessor:
                         chosen_lang,
                         req_id,
                         correlation_id,
+                        summary=shaped,
                         silent=True,
                     )
                     logger.info(
@@ -390,6 +393,8 @@ class URLProcessor:
         chosen_lang: str,
         req_id: int,
         correlation_id: str | None,
+        *,
+        summary: dict[str, Any] | None = None,
         silent: bool = False,
     ) -> None:
         """Generate and persist additional insights using the LLM."""
@@ -405,6 +410,7 @@ class URLProcessor:
                 chosen_lang=chosen_lang,
                 req_id=req_id,
                 correlation_id=correlation_id,
+                summary=summary,
             )
 
             if insights:

--- a/app/adapters/telegram/forward_processor.py
+++ b/app/adapters/telegram/forward_processor.py
@@ -194,6 +194,18 @@ class ForwardProcessor:
             from app.adapters.content.llm_summarizer import LLMSummarizer
 
             # Create LLMSummarizer instance with same dependencies as ForwardSummarizer
+            summary_payload: dict[str, Any] | None = None
+            try:
+                row = self.db.get_summary_by_request(req_id)
+                json_payload = row.get("json_payload") if row else None
+                if json_payload:
+                    summary_payload = json.loads(json_payload)
+            except Exception as exc:
+                logger.debug(
+                    "forward_insights_summary_load_failed",
+                    extra={"cid": correlation_id, "error": str(exc)},
+                )
+
             llm_summarizer = LLMSummarizer(
                 cfg=self.cfg,
                 db=self.db,
@@ -209,6 +221,7 @@ class ForwardProcessor:
                 chosen_lang=chosen_lang,
                 req_id=req_id,
                 correlation_id=correlation_id,
+                summary=summary_payload,
             )
 
             if insights:

--- a/app/core/summary_schema.py
+++ b/app/core/summary_schema.py
@@ -42,6 +42,21 @@ if PydanticAvailable:
         question: str
         answer: str
 
+    class InsightFact(BaseModel):
+        fact: str
+        why_it_matters: str | None = None
+        source_hint: str | None = None
+        confidence: float | str | None = None
+
+    class Insights(BaseModel):
+        topic_overview: str = Field(default="")
+        new_facts: list[InsightFact] = Field(default_factory=list)
+        open_questions: list[str] = Field(default_factory=list)
+        suggested_sources: list[str] = Field(default_factory=list)
+        expansion_topics: list[str] = Field(default_factory=list)
+        next_exploration: list[str] = Field(default_factory=list)
+        caution: str | None = None
+
     class TopicTaxonomy(BaseModel):
         label: str
         score: float = 0.0
@@ -80,3 +95,4 @@ if PydanticAvailable:
         confidence: float = Field(default=1.0, ge=0.0, le=1.0)
         forwarded_post_extras: ForwardedPostExtras | None = None
         key_points_to_remember: list[str] = Field(default_factory=list)
+        insights: Insights = Field(default_factory=Insights)

--- a/app/prompts/summary_system_en.txt
+++ b/app/prompts/summary_system_en.txt
@@ -12,6 +12,17 @@ Top-level keys (exactly these, no extras):
 - answered_questions
 - readability
 - seo_keywords
+- metadata
+- extractive_quotes
+- highlights
+- questions_answered
+- categories
+- topic_taxonomy
+- hallucination_risk
+- confidence
+- forwarded_post_extras
+- key_points_to_remember
+- insights
 
 Field requirements:
 - summary_250: string, max 250 characters. One-sentence, high-signal summary that ends cleanly.
@@ -25,6 +36,24 @@ Field requirements:
 - answered_questions: array of strings capturing questions the content answers. No duplicates.
 - readability: object { method: string (e.g., "Flesch-Kincaid"), score: number, level: string }.
 - seo_keywords: array of strings (5–15 items), lowercase, deduplicated.
+- metadata: object with keys { title, canonical_url, domain, author, published_at, last_updated } (strings or null). Fill from article when available.
+- extractive_quotes: array of objects { text: string, source_span: string|null } representing up to 5 verbatim pull quotes.
+- highlights: array of 5–10 short bullet strings.
+- questions_answered: array of objects { question: string, answer: string } describing Q&A pairs surfaced in the content.
+- categories: array of short classification strings.
+- topic_taxonomy: array of objects { label: string, score: number, path: string|null } for hierarchical categories.
+- hallucination_risk: string enum low|med|high summarizing factual confidence.
+- confidence: number between 0 and 1 expressing overall certainty.
+- forwarded_post_extras: object|null capturing Telegram metadata { channel_id, channel_title, channel_username, message_id, post_datetime, hashtags, mentions }.
+- key_points_to_remember: array of strings listing enduring takeaways.
+- insights: object with keys:
+  * topic_overview: string summarizing broader context.
+  * new_facts: array of objects { fact: string, why_it_matters: string|null, source_hint: string|null, confidence: number|string|null } containing 4–6 beyond-text insights.
+  * open_questions: array of strings (3–6 items).
+  * suggested_sources: array of strings referencing follow-up reading.
+  * expansion_topics: array of strings with adjacent themes to explore.
+  * next_exploration: array of strings outlining experiments, hypotheses, or next steps.
+  * caution: string|null flagging caveats or uncertainty.
 
 Rules:
 - Output all strings in the language requested in the user message.

--- a/app/prompts/summary_system_ru.txt
+++ b/app/prompts/summary_system_ru.txt
@@ -12,6 +12,17 @@
 - answered_questions
 - readability
 - seo_keywords
+- metadata
+- extractive_quotes
+- highlights
+- questions_answered
+- categories
+- topic_taxonomy
+- hallucination_risk
+- confidence
+- forwarded_post_extras
+- key_points_to_remember
+- insights
 
 Требования к полям:
 - summary_250: строка, максимум 250 символов. Одна ёмкая фраза с завершённой мыслью.
@@ -25,6 +36,24 @@
 - answered_questions: массив строк с вопросами, на которые отвечает материал. Без дубликатов.
 - readability: объект { method: string (например, «Flesch-Kincaid»), score: number, level: string }.
 - seo_keywords: массив строк (5–15), в нижнем регистре, без дубликатов.
+- metadata: объект с ключами { title, canonical_url, domain, author, published_at, last_updated } (строки или null). Заполняйте из статьи, если данные доступны.
+- extractive_quotes: массив объектов { text: string, source_span: string|null } — до 5 дословных цитат.
+- highlights: массив из 5–10 коротких пунктов.
+- questions_answered: массив объектов { question: string, answer: string } с парами «вопрос–ответ».
+- categories: массив коротких меток категорий.
+- topic_taxonomy: массив объектов { label: string, score: number, path: string|null } для иерархии тем.
+- hallucination_risk: строка low|med|high, оценивающая риск галлюцинаций.
+- confidence: число от 0 до 1, отражающее уверенность модели.
+- forwarded_post_extras: объект или null с данными Telegram { channel_id, channel_title, channel_username, message_id, post_datetime, hashtags, mentions }.
+- key_points_to_remember: массив строк с ключевыми выводами.
+- insights: объект со следующими ключами:
+  * topic_overview: строка с широким контекстом.
+  * new_facts: массив объектов { fact: string, why_it_matters: string|null, source_hint: string|null, confidence: number|string|null } с 4–6 новыми фактами.
+  * open_questions: массив строк (3–6 позиций).
+  * suggested_sources: массив строк с источниками для изучения.
+  * expansion_topics: массив строк с смежными темами.
+  * next_exploration: массив строк с идеями дальнейших шагов/гипотез.
+  * caution: строка или null с предупреждениями/ограничениями.
 
 Правила:
 - Пишите на языке, запрошенном в пользовательском сообщении.


### PR DESCRIPTION
## Summary
- raise LLM token budgets to avoid truncated completions and persist the last shaped summary so downstream flows can reuse its insights.
- shape and validate the new `insights` section in the summary contract, including chunk aggregation support and expanded Pydantic/JSON schemas.
- update the English and Russian system prompts plus downstream processors to expect the richer summary payload and reuse the included insights instead of issuing extra LLM calls.

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68d8f99aa1f0832c91774ee3b98f6a63