### PR TITLE
Fix secrets usage in update-locks workflow

### DIFF
--- a/.github/workflows/update-locks.yml
+++ b/.github/workflows/update-locks.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   update-locks:
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_PR_TOKEN: ${{ secrets.ACTIONS_PR_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -48,11 +50,11 @@ jobs:
 
       # Prefer a personal access token if provided, since some repos block GITHUB_TOKEN PRs
       - name: Create Pull Request (using PAT if provided)
-        if: steps.changes.outputs.changes == 'true' && secrets.ACTIONS_PR_TOKEN != ''
+        if: steps.changes.outputs.changes == 'true' && env.ACTIONS_PR_TOKEN != ''
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.ACTIONS_PR_TOKEN }}
+          token: ${{ env.ACTIONS_PR_TOKEN }}
           commit-message: "chore(lock): update requirements via uv compile"
           title: "chore(lock): update requirements"
           body: |
@@ -67,7 +69,7 @@ jobs:
             requirements-dev.txt
 
       - name: Create Pull Request (best-effort with GITHUB_TOKEN)
-        if: steps.changes.outputs.changes == 'true' && (secrets.ACTIONS_PR_TOKEN == '')
+        if: steps.changes.outputs.changes == 'true' && (env.ACTIONS_PR_TOKEN == '')
         id: cpr_fallback
         continue-on-error: true
         uses: peter-evans/create-pull-request@v7
@@ -86,7 +88,7 @@ jobs:
             requirements-dev.txt
 
       - name: Note PR permission restriction
-        if: steps.changes.outputs.changes == 'true' && (secrets.ACTIONS_PR_TOKEN == '')
+        if: steps.changes.outputs.changes == 'true' && (env.ACTIONS_PR_TOKEN == '')
         run: |
           echo "::warning::Repository blocks GitHub Actions from creating PRs."
           echo "Set a repo/org secret 'ACTIONS_PR_TOKEN' with 'contents' and 'pull_requests' write permissions (fine-grained PAT), or enable the setting to allow Actions to create PRs."


### PR DESCRIPTION
## Summary
- expose the optional ACTIONS_PR_TOKEN secret as a job environment variable in the lockfile workflow
- reference the environment variable in conditional expressions to avoid invalid syntax errors

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68d91467f9e4832ca1dfbc8bab23bf29