### PR TITLE
Add user interaction persistence

### DIFF
--- a/app/adapters/content/llm_summarizer.py
+++ b/app/adapters/content/llm_summarizer.py
@@ -1620,12 +1620,25 @@ class LLMSummarizer:
         request_id: int | None = None,
     ) -> None:
         """Update an existing user interaction record."""
-        # Note: This method is a placeholder for future user interaction tracking
-        # The current database schema doesn't include user_interactions table
-        logger.debug(
-            "user_interaction_update_placeholder",
-            extra={"interaction_id": interaction_id, "response_type": response_type},
-        )
+
+        if interaction_id is None or interaction_id <= 0:
+            return
+
+        try:
+            self.db.update_user_interaction(
+                interaction_id=interaction_id,
+                response_sent=response_sent,
+                response_type=response_type,
+                error_occurred=error_occurred,
+                error_message=error_message,
+                processing_time_ms=processing_time_ms,
+                request_id=request_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "user_interaction_update_failed",
+                extra={"interaction_id": interaction_id, "error": str(exc)},
+            )
 
     @property
     def last_llm_result(self) -> Any | None:

--- a/app/adapters/content/url_processor.py
+++ b/app/adapters/content/url_processor.py
@@ -661,9 +661,22 @@ class URLProcessor:
         request_id: int | None = None,
     ) -> None:
         """Update an existing user interaction record."""
-        # Note: This method is a placeholder for future user interaction tracking
-        # The current database schema doesn't include user_interactions table
-        logger.debug(
-            "user_interaction_update_placeholder",
-            extra={"interaction_id": interaction_id, "response_type": response_type},
-        )
+
+        if interaction_id <= 0:
+            return
+
+        try:
+            self.db.update_user_interaction(
+                interaction_id=interaction_id,
+                response_sent=response_sent,
+                response_type=response_type,
+                error_occurred=error_occurred,
+                error_message=error_message,
+                processing_time_ms=processing_time_ms,
+                request_id=request_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "user_interaction_update_failed",
+                extra={"interaction_id": interaction_id, "error": str(exc)},
+            )

--- a/app/adapters/telegram/command_processor.py
+++ b/app/adapters/telegram/command_processor.py
@@ -450,12 +450,25 @@ class CommandProcessor:
         request_id: int | None = None,
     ) -> None:
         """Update an existing user interaction record."""
-        # Note: This method is a placeholder for future user interaction tracking
-        # The current database schema doesn't include user_interactions table
-        logger.debug(
-            "user_interaction_update_placeholder",
-            extra={"interaction_id": interaction_id, "response_type": response_type},
-        )
+
+        if interaction_id <= 0:
+            return
+
+        try:
+            self.db.update_user_interaction(
+                interaction_id=interaction_id,
+                response_sent=response_sent,
+                response_type=response_type,
+                error_occurred=error_occurred,
+                error_message=error_message,
+                processing_time_ms=processing_time_ms,
+                request_id=request_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "user_interaction_update_failed",
+                extra={"interaction_id": interaction_id, "error": str(exc)},
+            )
 
     async def handle_unread_command(
         self, message: Any, uid: int, correlation_id: str, interaction_id: int, start_time: float

--- a/app/adapters/telegram/forward_summarizer.py
+++ b/app/adapters/telegram/forward_summarizer.py
@@ -455,9 +455,22 @@ class ForwardSummarizer:
         request_id: int | None = None,
     ) -> None:
         """Update an existing user interaction record."""
-        # Note: This method is a placeholder for future user interaction tracking
-        # The current database schema doesn't include user_interactions table
-        logger.debug(
-            "user_interaction_update_placeholder",
-            extra={"interaction_id": interaction_id, "response_type": response_type},
-        )
+
+        if interaction_id <= 0:
+            return
+
+        try:
+            self.db.update_user_interaction(
+                interaction_id=interaction_id,
+                response_sent=response_sent,
+                response_type=response_type,
+                error_occurred=error_occurred,
+                error_message=error_message,
+                processing_time_ms=processing_time_ms,
+                request_id=request_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "user_interaction_update_failed",
+                extra={"interaction_id": interaction_id, "error": str(exc)},
+            )

--- a/app/adapters/telegram/message_handler.py
+++ b/app/adapters/telegram/message_handler.py
@@ -38,11 +38,13 @@ class MessageHandler:
         # Initialize components
         self.access_controller = AccessController(
             cfg=cfg,
+            db=db,
             response_formatter=response_formatter,
             audit_func=self._audit,
         )
 
         self.url_handler = URLHandler(
+            db=db,
             response_formatter=response_formatter,
             url_processor=url_processor,
         )

--- a/tests/test_user_interactions.py
+++ b/tests/test_user_interactions.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import Mock
+
+from app.adapters.telegram.command_processor import CommandProcessor
+from app.adapters.telegram.message_router import MessageRouter
+from app.adapters.telegram.url_handler import URLHandler
+from app.config import AppConfig, FirecrawlConfig, OpenRouterConfig, RuntimeConfig, TelegramConfig
+from app.db.database import Database
+
+
+def _make_config() -> AppConfig:
+    return AppConfig(
+        telegram=TelegramConfig(
+            api_id=1,
+            api_hash="hash",
+            bot_token="token",
+            allowed_user_ids=(1,),
+        ),
+        firecrawl=FirecrawlConfig(api_key="firecrawl-key"),
+        openrouter=OpenRouterConfig(
+            api_key="openrouter-key",
+            model="test-model",
+            fallback_models=tuple(),
+            http_referer=None,
+            x_title=None,
+        ),
+        runtime=RuntimeConfig(
+            db_path=":memory:",
+            log_level="INFO",
+            request_timeout_sec=10,
+            preferred_lang="en",
+            debug_payloads=False,
+        ),
+    )
+
+
+def _make_db(tmp_path) -> Database:
+    db = Database(str(tmp_path / "interactions.db"))
+    db.migrate()
+    return db
+
+
+def test_message_router_logs_interaction(tmp_path) -> None:
+    cfg = _make_config()
+    db = _make_db(tmp_path)
+
+    router = MessageRouter(
+        cfg=cfg,
+        db=db,
+        access_controller=Mock(),
+        command_processor=Mock(),
+        url_handler=cast(URLHandler, SimpleNamespace(url_processor=Mock())),
+        forward_processor=Mock(),
+        response_formatter=Mock(),
+        audit_func=lambda *args, **kwargs: None,
+    )
+
+    interaction_id = router._log_user_interaction(  # noqa: SLF001
+        user_id=42,
+        chat_id=99,
+        message_id=7,
+        interaction_type="command",
+        command="/start",
+        input_text="hello",
+        input_url=None,
+        has_forward=True,
+        forward_from_chat_id=555,
+        forward_from_chat_title="Forwarded",
+        forward_from_message_id=321,
+        media_type="text",
+        correlation_id="cid-123",
+    )
+
+    assert interaction_id > 0
+
+    row = db.fetchone("SELECT * FROM user_interactions WHERE id = ?", (interaction_id,))
+    assert row is not None
+    assert row["user_id"] == 42
+    assert row["interaction_type"] == "command"
+    assert row["command"] == "/start"
+    assert row["has_forward"] == 1
+    assert row["structured_output_enabled"] == 1
+    assert row["correlation_id"] == "cid-123"
+
+
+def test_command_processor_updates_interaction(tmp_path) -> None:
+    cfg = _make_config()
+    db = _make_db(tmp_path)
+
+    interaction_id = db.insert_user_interaction(
+        user_id=7,
+        interaction_type="command",
+        chat_id=11,
+        message_id=22,
+        command="/help",
+        input_text="help",
+        structured_output_enabled=True,
+    )
+
+    processor = CommandProcessor(
+        cfg=cfg,
+        response_formatter=Mock(),
+        db=db,
+        url_processor=Mock(),
+        audit_func=lambda *args, **kwargs: None,
+    )
+
+    processor._update_user_interaction(  # noqa: SLF001
+        interaction_id=interaction_id,
+        response_sent=True,
+        response_type="help",
+        error_occurred=True,
+        error_message="boom",
+        processing_time_ms=1234,
+        request_id=88,
+    )
+
+    row = db.fetchone(
+        "SELECT response_sent, response_type, error_occurred, error_message, processing_time_ms, request_id "
+        "FROM user_interactions WHERE id = ?",
+        (interaction_id,),
+    )
+
+    assert row is not None
+    assert row["response_sent"] == 1
+    assert row["response_type"] == "help"
+    assert row["error_occurred"] == 1
+    assert row["error_message"] == "boom"
+    assert row["processing_time_ms"] == 1234
+    assert row["request_id"] == 88


### PR DESCRIPTION
## Summary
- add a `user_interactions` table and helper methods for inserting and updating interaction metadata
- wire the new persistence helpers into the Telegram router and downstream components that record interaction progress
- add unit tests to confirm interactions are stored and updated when router and command logic runs

## Testing
- ruff check . --fix
- ruff format .
- mypy .
- pytest tests/test_user_interactions.py

------
https://chatgpt.com/codex/tasks/task_e_68d9202106b0832cb3a3be7d945cf5d5