### PR TITLE
Add helpers to upsert Telegram chats and users

### DIFF
--- a/app/adapters/content/content_extractor.py
+++ b/app/adapters/content/content_extractor.py
@@ -130,6 +130,8 @@ class ContentExtractor:
         self, message: Any, url_text: str, norm: str, dedupe: str, correlation_id: str | None
     ) -> int:
         """Handle request deduplication or creation."""
+        self._upsert_sender_metadata(message)
+
         existing_req = self.db.get_request_by_dedupe_hash(dedupe)
 
         if existing_req:
@@ -187,6 +189,51 @@ class ContentExtractor:
             logger.error("snapshot_error", extra={"error": str(e), "cid": correlation_id})
 
         return req_id
+
+    def _upsert_sender_metadata(self, message: Any) -> None:
+        """Persist sender user/chat metadata for the interaction."""
+
+        def _coerce_int(value: Any) -> int | None:
+            try:
+                return int(value) if value is not None else None
+            except (TypeError, ValueError):
+                return None
+
+        chat_obj = getattr(message, "chat", None)
+        chat_id = _coerce_int(getattr(chat_obj, "id", None) if chat_obj is not None else None)
+        if chat_id is not None:
+            chat_type = getattr(chat_obj, "type", None)
+            chat_title = getattr(chat_obj, "title", None)
+            chat_username = getattr(chat_obj, "username", None)
+            try:
+                self.db.upsert_chat(
+                    chat_id=chat_id,
+                    type_=str(chat_type) if chat_type is not None else None,
+                    title=str(chat_title) if isinstance(chat_title, str) else None,
+                    username=str(chat_username) if isinstance(chat_username, str) else None,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "chat_upsert_failed",
+                    extra={"chat_id": chat_id, "error": str(exc)},
+                )
+
+        from_user_obj = getattr(message, "from_user", None)
+        user_id = _coerce_int(
+            getattr(from_user_obj, "id", None) if from_user_obj is not None else None
+        )
+        if user_id is not None:
+            username = getattr(from_user_obj, "username", None)
+            try:
+                self.db.upsert_user(
+                    telegram_user_id=user_id,
+                    username=str(username) if isinstance(username, str) else None,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "user_upsert_failed",
+                    extra={"user_id": user_id, "error": str(exc)},
+                )
 
     async def _extract_or_reuse_content(
         self,

--- a/app/adapters/telegram/message_persistence.py
+++ b/app/adapters/telegram/message_persistence.py
@@ -35,6 +35,39 @@ class MessagePersistence:
         chat_id_raw = getattr(chat_obj, "id", 0) if chat_obj is not None else None
         chat_id = int(chat_id_raw) if chat_id_raw is not None else None
 
+        if chat_id is not None:
+            chat_type = getattr(chat_obj, "type", None)
+            chat_title = getattr(chat_obj, "title", None)
+            chat_username = getattr(chat_obj, "username", None)
+            try:
+                self.db.upsert_chat(
+                    chat_id=chat_id,
+                    type_=str(chat_type) if chat_type is not None else None,
+                    title=str(chat_title) if isinstance(chat_title, str) else None,
+                    username=str(chat_username) if isinstance(chat_username, str) else None,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "chat_upsert_failed",
+                    extra={"chat_id": chat_id, "error": str(exc)},
+                )
+
+        from_user_obj = getattr(message, "from_user", None)
+        user_id_raw = getattr(from_user_obj, "id", 0) if from_user_obj is not None else None
+        user_id = int(user_id_raw) if user_id_raw is not None else None
+        if user_id is not None:
+            username = getattr(from_user_obj, "username", None)
+            try:
+                self.db.upsert_user(
+                    telegram_user_id=user_id,
+                    username=str(username) if isinstance(username, str) else None,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "user_upsert_failed",
+                    extra={"user_id": user_id, "error": str(exc)},
+                )
+
         date_ts = self._to_epoch(
             getattr(message, "date", None) or getattr(message, "forward_date", None)
         )

--- a/tests/test_user_chat_upsert.py
+++ b/tests/test_user_chat_upsert.py
@@ -1,0 +1,128 @@
+"""Tests for user and chat upsert behavior during message persistence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from app.adapters.telegram.message_persistence import MessagePersistence
+from app.db.database import Database
+
+
+@dataclass
+class _DummyChat:
+    id: int
+    type: str | None = None
+    title: str | None = None
+    username: str | None = None
+
+
+@dataclass
+class _DummyUser:
+    id: int
+    username: str | None = None
+
+
+class _DummyMessage:
+    """Minimal message stub exposing attributes used by MessagePersistence."""
+
+    def __init__(
+        self,
+        *,
+        chat: _DummyChat,
+        user: _DummyUser,
+        text: str = "hello",
+        date: int = 1,
+    ) -> None:
+        self.chat = chat
+        self.from_user = user
+        self.text = text
+        self.caption = None
+        self.entities: list[dict[str, str]] = []
+        self.caption_entities: list[dict[str, str]] = []
+        self.id = 1
+        self.message_id = 1
+        self.date = date
+
+    def to_dict(self) -> dict[str, int]:
+        return {"id": self.id, "message_id": self.message_id}
+
+
+@pytest.fixture()
+def db(tmp_path) -> Database:
+    path = tmp_path / "app.db"
+    database = Database(str(path))
+    database.migrate()
+    return database
+
+
+@pytest.fixture()
+def persistence(db: Database) -> MessagePersistence:
+    return MessagePersistence(db=db)
+
+
+def _create_request(db: Database) -> int:
+    return db.create_request(
+        type_="url",
+        status="pending",
+        correlation_id=None,
+        chat_id=1,
+        user_id=1,
+        input_url="https://example.com",
+        normalized_url="https://example.com",
+        dedupe_hash=None,
+        input_message_id=1,
+        content_text="https://example.com",
+        route_version=1,
+    )
+
+
+def test_persist_message_snapshot_populates_user_and_chat(
+    db: Database, persistence: MessagePersistence
+) -> None:
+    req_id = _create_request(db)
+    message = _DummyMessage(
+        chat=_DummyChat(id=101, type="private", title="My Chat", username="chatuser"),
+        user=_DummyUser(id=202, username="alice"),
+    )
+
+    persistence.persist_message_snapshot(req_id, message)
+
+    user_row = db.fetchone("SELECT username FROM users WHERE telegram_user_id = ?", (202,))
+    assert user_row is not None
+    assert user_row["username"] == "alice"
+
+    chat_row = db.fetchone("SELECT type, title, username FROM chats WHERE chat_id = ?", (101,))
+    assert chat_row is not None
+    assert chat_row["type"] == "private"
+    assert chat_row["title"] == "My Chat"
+    assert chat_row["username"] == "chatuser"
+
+
+def test_persist_message_snapshot_refreshes_user_and_chat(
+    db: Database, persistence: MessagePersistence
+) -> None:
+    first_req = _create_request(db)
+    first_message = _DummyMessage(
+        chat=_DummyChat(id=303, type="group", title="Old Title", username="old_chat"),
+        user=_DummyUser(id=404, username="old_user"),
+    )
+    persistence.persist_message_snapshot(first_req, first_message)
+
+    second_req = _create_request(db)
+    second_message = _DummyMessage(
+        chat=_DummyChat(id=303, type="supergroup", title="New Title", username="new_chat"),
+        user=_DummyUser(id=404, username="new_user"),
+    )
+    persistence.persist_message_snapshot(second_req, second_message)
+
+    user_row = db.fetchone("SELECT username FROM users WHERE telegram_user_id = ?", (404,))
+    assert user_row is not None
+    assert user_row["username"] == "new_user"
+
+    chat_row = db.fetchone("SELECT type, title, username FROM chats WHERE chat_id = ?", (303,))
+    assert chat_row is not None
+    assert chat_row["type"] == "supergroup"
+    assert chat_row["title"] == "New Title"
+    assert chat_row["username"] == "new_chat"

--- a/tests/test_user_interaction_update.py
+++ b/tests/test_user_interaction_update.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import pytest
+
+from app.db.database import Database
+
+
+@pytest.fixture()
+def db(tmp_path) -> Database:
+    path = tmp_path / "app.db"
+    database = Database(str(path))
+    database.migrate()
+    with database.connect() as conn:
+        conn.execute(
+            """
+            CREATE TABLE user_interactions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                response_sent INTEGER,
+                response_type TEXT,
+                error_occurred INTEGER,
+                error_message TEXT,
+                processing_time_ms INTEGER,
+                request_id INTEGER
+            )
+            """
+        )
+        conn.commit()
+    return database
+
+
+def _insert_interaction(db: Database) -> int:
+    with db.connect() as conn:
+        cur = conn.execute(
+            """
+            INSERT INTO user_interactions (
+                response_sent,
+                response_type,
+                error_occurred,
+                error_message,
+                processing_time_ms,
+                request_id
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (0, "initial", 1, "pending", 250, 7),
+        )
+        conn.commit()
+        return int(cur.lastrowid)
+
+
+def test_update_user_interaction_updates_allowed_fields(db: Database) -> None:
+    interaction_id = _insert_interaction(db)
+
+    db.update_user_interaction(
+        interaction_id=interaction_id,
+        updates={
+            "response_sent": True,
+            "response_type": "summary",
+            "error_occurred": False,
+            "error_message": None,
+            "processing_time_ms": 1234,
+            "request_id": 42,
+        },
+    )
+
+    row = db.fetchone("SELECT * FROM user_interactions WHERE id = ?", (interaction_id,))
+    assert row is not None
+    assert row["response_sent"] == 1
+    assert row["response_type"] == "summary"
+    assert row["error_occurred"] == 0
+    assert row["error_message"] is None
+    assert row["processing_time_ms"] == 1234
+    assert row["request_id"] == 42
+
+
+def test_update_user_interaction_rejects_unknown_field(db: Database) -> None:
+    interaction_id = _insert_interaction(db)
+
+    with pytest.raises(ValueError):
+        db.update_user_interaction(interaction_id=interaction_id, updates={"invalid": "noop"})
+
+
+def test_update_user_interaction_ignores_empty_updates(db: Database) -> None:
+    interaction_id = _insert_interaction(db)
+    before = db.fetchone("SELECT * FROM user_interactions WHERE id = ?", (interaction_id,))
+    assert before is not None
+
+    db.update_user_interaction(interaction_id=interaction_id, updates={})
+
+    after = db.fetchone("SELECT * FROM user_interactions WHERE id = ?", (interaction_id,))
+    assert after is not None
+    assert dict(after) == dict(before)


### PR DESCRIPTION
## Summary
- add database helpers to upsert Telegram user and chat metadata and reuse them across request flows
- update message persistence and request creation paths to refresh sender/chat records on every interaction
- cover the new upsert behaviour with tests ensuring users and chats are inserted and updated

## Testing
- pytest tests/test_user_chat_upsert.py
- ruff check . --fix
- ruff format .
- mypy .

------
https://chatgpt.com/codex/tasks/task_e_68d9202a64b8832ca473f8f84eededba