### PR TITLE
Optimize regex reuse in URL utilities and summarizer

### DIFF
--- a/app/adapters/content/llm_summarizer.py
+++ b/app/adapters/content/llm_summarizer.py
@@ -29,6 +29,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+_STRING_LIST_SPLITTER_RE = re.compile(r"[\n\r•;]+")
+
+
 class LLMSummarizer:
     """Handles AI summarization calls and response processing."""
 
@@ -578,8 +581,7 @@ class LLMSummarizer:
             cleaned = value.strip()
             if not cleaned:
                 return []
-            splitter = re.compile(r"[\n\r•;]+")
-            parts = [part.strip(" -•\t") for part in splitter.split(cleaned)]
+            parts = [part.strip(" -•\t") for part in _STRING_LIST_SPLITTER_RE.split(cleaned)]
             return [part for part in parts if part]
 
         if value is None:


### PR DESCRIPTION
## Summary
- precompile reusable URL regex patterns and dangerous substring filters to eliminate redundant compilation work
- reuse the string list splitter regex in the LLM summarizer to avoid recompilation when coercing list inputs

## Testing
- ruff check . --fix
- ruff format .
- mypy .
- pytest test_url_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68d9492f87f0832ca41a8f87568f44d9