### PR TITLE
Fix crawl result insert placeholders and unread ordering

### DIFF
--- a/app/db/database.py
+++ b/app/db/database.py
@@ -309,7 +309,7 @@ class Database:
             success_int: int | None
             if isinstance(success_val, bool):
                 success_int = 1 if success_val else 0
-            elif isinstance(success_val, (int, float)):
+            elif isinstance(success_val, int | float):
                 success_int = 1 if bool(success_val) else 0
             else:
                 success_int = None
@@ -1483,7 +1483,7 @@ class Database:
             "correlation_id, content_markdown, content_html, structured_json, metadata_json, links_json, "
             "screenshots_paths_json, firecrawl_success, firecrawl_error_code, firecrawl_error_message, "
             "firecrawl_details_json, raw_response_json, latency_ms, error_text) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
         )
         success_value: int | None
         if isinstance(firecrawl_success, bool):
@@ -1713,7 +1713,7 @@ class Database:
             FROM summaries s
             JOIN requests r ON s.request_id = r.id
             WHERE s.is_read = 0
-            ORDER BY s.created_at DESC
+            ORDER BY s.created_at ASC, s.id ASC
             LIMIT ?
         """
         with self.connect() as conn:

--- a/tests/test_user_interaction_update.py
+++ b/tests/test_user_interaction_update.py
@@ -11,6 +11,7 @@ def db(tmp_path) -> Database:
     database = Database(str(path))
     database.migrate()
     with database.connect() as conn:
+        conn.execute("DROP TABLE IF EXISTS user_interactions")
         conn.execute(
             """
             CREATE TABLE user_interactions (


### PR DESCRIPTION
## Summary
- ensure crawl_results inserts include all columns to avoid placeholder mismatches
- return unread summaries in a deterministic oldest-first order
- reset the user_interactions test table before creating minimal schemas

## Testing
- pytest tests -q

------
https://chatgpt.com/codex/tasks/task_e_68da2a8f3050832c8b85eccd746e130d