### PR TITLE
Fix crawl result insert placeholders and reset test fixture schema

### DIFF
--- a/app/db/database.py
+++ b/app/db/database.py
@@ -309,7 +309,7 @@ class Database:
             success_int: int | None
             if isinstance(success_val, bool):
                 success_int = 1 if success_val else 0
-            elif isinstance(success_val, (int, float)):
+            elif isinstance(success_val, int | float):
                 success_int = 1 if bool(success_val) else 0
             else:
                 success_int = None
@@ -1483,7 +1483,7 @@ class Database:
             "correlation_id, content_markdown, content_html, structured_json, metadata_json, links_json, "
             "screenshots_paths_json, firecrawl_success, firecrawl_error_code, firecrawl_error_message, "
             "firecrawl_details_json, raw_response_json, latency_ms, error_text) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
         )
         success_value: int | None
         if isinstance(firecrawl_success, bool):

--- a/tests/test_user_interaction_update.py
+++ b/tests/test_user_interaction_update.py
@@ -11,6 +11,7 @@ def db(tmp_path) -> Database:
     database = Database(str(path))
     database.migrate()
     with database.connect() as conn:
+        conn.execute("DROP TABLE IF EXISTS user_interactions")
         conn.execute(
             """
             CREATE TABLE user_interactions (


### PR DESCRIPTION
## Summary
- add the missing placeholder when inserting crawl results so column counts match the schema
- drop any pre-existing user_interactions table in the interaction update fixture to align with the simplified test schema
- modernize the firecrawl success type check to satisfy linting

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68da2b4810e8832c8228d84218b26837