### PR TITLE
Integrate Pydantic models for external payloads

### DIFF
--- a/app/adapters/external/firecrawl_parser.py
+++ b/app/adapters/external/firecrawl_parser.py
@@ -5,33 +5,66 @@ import json
 import logging
 import time
 from collections.abc import Callable
-from dataclasses import dataclass
 from typing import Any
 
 import httpx
+from pydantic import BaseModel, ConfigDict, Field
 
 from app.core.logging_utils import truncate_log_content
 
 
-@dataclass
-class FirecrawlResult:
-    status: str
-    http_status: int | None
-    content_markdown: str | None
-    content_html: str | None
-    structured_json: dict | None
-    metadata_json: dict | None
-    links_json: dict | None
-    response_success: bool | None
-    response_error_code: str | None
-    response_error_message: str | None
-    response_details: dict | list | None
-    latency_ms: int | None
-    error_text: str | None
-    source_url: str | None = None
-    endpoint: str | None = "/v1/scrape"
-    options_json: dict | None = None
-    correlation_id: str | None = None  # Firecrawl's cid field
+class FirecrawlResult(BaseModel):
+    """Normalized representation of a Firecrawl `/v1/scrape` response."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: str = Field(description="High-level status of the crawl attempt.")
+    http_status: int | None = Field(
+        default=None, description="HTTP status code returned by Firecrawl."
+    )
+    content_markdown: str | None = Field(
+        default=None, description="Markdown content returned by Firecrawl."
+    )
+    content_html: str | None = Field(
+        default=None, description="HTML content returned by Firecrawl."
+    )
+    structured_json: dict[str, Any] | None = Field(
+        default=None, description="Structured JSON payload from Firecrawl."
+    )
+    metadata_json: dict[str, Any] | None = Field(
+        default=None, description="Metadata block supplied by Firecrawl."
+    )
+    links_json: dict[str, Any] | list[Any] | None = Field(
+        default=None, description="Outbound links metadata from Firecrawl."
+    )
+    response_success: bool | None = Field(
+        default=None, description="Whether Firecrawl reported success."
+    )
+    response_error_code: str | None = Field(
+        default=None, description="Firecrawl-provided error code, if any."
+    )
+    response_error_message: str | None = Field(
+        default=None, description="Firecrawl-provided error message, if any."
+    )
+    response_details: dict[str, Any] | list[Any] | None = Field(
+        default=None, description="Additional detail array/object from Firecrawl."
+    )
+    latency_ms: int | None = Field(
+        default=None, description="Client-observed latency for the call."
+    )
+    error_text: str | None = Field(
+        default=None, description="Client-derived error message, if any."
+    )
+    source_url: str | None = Field(default=None, description="URL that was submitted to Firecrawl.")
+    endpoint: str | None = Field(
+        default="/v1/scrape", description="Firecrawl endpoint that was called."
+    )
+    options_json: dict[str, Any] | None = Field(
+        default=None, description="Options payload sent to Firecrawl."
+    )
+    correlation_id: str | None = Field(
+        default=None, description="Firecrawl correlation identifier (cid)."
+    )
 
 
 class FirecrawlClient:

--- a/app/models/llm/llm_models.py
+++ b/app/models/llm/llm_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, StrictBool
 
 
 class LLMCallResult(BaseModel):
@@ -73,7 +73,10 @@ class ChatRequest(BaseModel):
         default=None, description="Maximum tokens to generate in the completion."
     )
     top_p: float | None = Field(default=None, description="Nucleus sampling parameter.")
-    stream: bool = Field(default=False, description="Whether to request a streaming response.")
+    stream: StrictBool = Field(
+        default=False,
+        description="Whether to request a streaming response.",
+    )
     request_id: int | None = Field(
         default=None, description="Internal request identifier for tracing."
     )

--- a/app/models/llm/llm_models.py
+++ b/app/models/llm/llm_models.py
@@ -1,43 +1,85 @@
-"""Data models for LLM interactions."""
+"""Data models for LLM interactions backed by Pydantic validation."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Any
 
+from pydantic import BaseModel, ConfigDict, Field
 
-@dataclass
-class LLMCallResult:
+
+class LLMCallResult(BaseModel):
     """Result of an LLM API call with comprehensive metadata."""
 
-    status: str
-    model: str | None
-    response_text: str | None
-    response_json: dict | None
-    openrouter_response_text: str | None = None
-    openrouter_response_json: dict | None = None
-    tokens_prompt: int | None = None
-    tokens_completion: int | None = None
-    cost_usd: float | None = None
-    latency_ms: int | None = None
-    error_text: str | None = None
-    request_headers: dict | None = None
-    request_messages: list[dict] | None = None
-    endpoint: str | None = "/api/v1/chat/completions"
-    structured_output_used: bool = False
-    structured_output_mode: str | None = None
-    error_context: dict[str, Any] | None = None
+    model_config = ConfigDict(extra="forbid")
+
+    status: str = Field(description="High-level result status (ok, error, etc.).")
+    model: str | None = Field(default=None, description="Model that produced the response.")
+    response_text: str | None = Field(
+        default=None, description="Primary text response returned by the provider."
+    )
+    response_json: dict[str, Any] | None = Field(
+        default=None, description="Structured JSON payload returned by the provider."
+    )
+    openrouter_response_text: str | None = Field(
+        default=None, description="Raw OpenRouter response text (pre-parsing)."
+    )
+    openrouter_response_json: dict[str, Any] | None = Field(
+        default=None, description="Raw OpenRouter JSON payload (pre-processing)."
+    )
+    tokens_prompt: int | None = Field(
+        default=None, description="Prompt tokens consumed by the request."
+    )
+    tokens_completion: int | None = Field(
+        default=None, description="Completion tokens produced by the request."
+    )
+    cost_usd: float | None = Field(default=None, description="Estimated USD cost for the request.")
+    latency_ms: int | None = Field(
+        default=None, description="Observed latency for the LLM request in milliseconds."
+    )
+    error_text: str | None = Field(default=None, description="Error message when the call fails.")
+    request_headers: dict[str, Any] | None = Field(
+        default=None, description="HTTP headers sent with the request."
+    )
+    request_messages: list[dict[str, Any]] | None = Field(
+        default=None, description="Messages payload submitted to the chat endpoint."
+    )
+    endpoint: str | None = Field(
+        default="/api/v1/chat/completions",
+        description="Endpoint used for the LLM call.",
+    )
+    structured_output_used: bool = Field(
+        default=False, description="Whether structured outputs were requested."
+    )
+    structured_output_mode: str | None = Field(
+        default=None, description="Structured output mode requested (if any)."
+    )
+    error_context: dict[str, Any] | None = Field(
+        default=None, description="Additional context about encountered errors."
+    )
 
 
-@dataclass
-class ChatRequest:
+class ChatRequest(BaseModel):
     """Request parameters for chat completions."""
 
-    messages: list[dict[str, str]]
-    temperature: float = 0.2
-    max_tokens: int | None = None
-    top_p: float | None = None
-    stream: bool = False
-    request_id: int | None = None
-    response_format: dict[str, Any] | None = None
-    model_override: str | None = None
+    model_config = ConfigDict(extra="forbid")
+
+    messages: list[dict[str, str]] = Field(
+        description="Conversation messages to send to the chat endpoint."
+    )
+    temperature: float = Field(
+        default=0.2, description="Sampling temperature for the chat completion."
+    )
+    max_tokens: int | None = Field(
+        default=None, description="Maximum tokens to generate in the completion."
+    )
+    top_p: float | None = Field(default=None, description="Nucleus sampling parameter.")
+    stream: bool = Field(default=False, description="Whether to request a streaming response.")
+    request_id: int | None = Field(
+        default=None, description="Internal request identifier for tracing."
+    )
+    response_format: dict[str, Any] | None = Field(
+        default=None, description="Structured output schema requested from the model."
+    )
+    model_override: str | None = Field(
+        default=None, description="Override model name for this specific call."
+    )


### PR DESCRIPTION
## Summary
- replace the FirecrawlResult dataclass with a Pydantic BaseModel to enforce response structure and field documentation
- migrate LLMCallResult and ChatRequest data containers to Pydantic for consistent validation of OpenRouter requests and responses

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68da439d78ac832cb48a56056a772228