### PR TITLE
Use Peewee JSON fields and native payloads

### DIFF
--- a/app/adapters/content/llm_summarizer.py
+++ b/app/adapters/content/llm_summarizer.py
@@ -785,11 +785,11 @@ class LLMSummarizer:
 
         # Persist summary
         try:
-            insights_json = json.dumps(self._last_insights) if self._last_insights else None
+            insights_json = self._last_insights if self._last_insights else None
             new_version = self.db.upsert_summary(
                 request_id=req_id,
                 lang=chosen_lang,
-                json_payload=json.dumps(summary_shaped),
+                json_payload=summary_shaped,
                 insights_json=insights_json,
                 is_read=True,  # LLM summarizer is for direct processing
             )
@@ -1184,16 +1184,15 @@ class LLMSummarizer:
     async def _persist_llm_call(self, llm: Any, req_id: int, correlation_id: str | None) -> None:
         """Persist LLM call to database."""
         try:
-            # json.dumps with default=str to avoid MagicMock serialization errors in tests
             self.db.insert_llm_call(
                 request_id=req_id,
                 provider="openrouter",
                 model=llm.model or self.cfg.openrouter.model,
                 endpoint=llm.endpoint,
-                request_headers_json=json.dumps(llm.request_headers or {}, default=str),
-                request_messages_json=json.dumps(llm.request_messages or [], default=str),
+                request_headers_json=llm.request_headers or {},
+                request_messages_json=list(llm.request_messages or []),
                 response_text=llm.response_text,
-                response_json=json.dumps(llm.response_json or {}, default=str),
+                response_json=llm.response_json or {},
                 tokens_prompt=llm.tokens_prompt,
                 tokens_completion=llm.tokens_completion,
                 cost_usd=llm.cost_usd,
@@ -1203,7 +1202,7 @@ class LLMSummarizer:
                 structured_output_used=getattr(llm, "structured_output_used", None),
                 structured_output_mode=getattr(llm, "structured_output_mode", None),
                 error_context_json=(
-                    json.dumps(getattr(llm, "error_context", {}) or {}, default=str)
+                    getattr(llm, "error_context", {})
                     if getattr(llm, "error_context", None) is not None
                     else None
                 ),

--- a/app/adapters/content/url_processor.py
+++ b/app/adapters/content/url_processor.py
@@ -7,10 +7,10 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from app.adapters.content.content_chunker import ContentChunker
 from app.adapters.content.content_extractor import ContentExtractor
@@ -297,7 +297,7 @@ class URLProcessor:
                     new_version = self.db.upsert_summary(
                         request_id=req_id,
                         lang=chosen_lang,
-                        json_payload=json.dumps(shaped),
+                        json_payload=shaped,
                         is_read=False,
                     )
                     self.db.update_request_status(req_id, "ok")
@@ -363,7 +363,7 @@ class URLProcessor:
             new_version = self.db.upsert_summary(
                 request_id=req_id,
                 lang=chosen_lang,
-                json_payload=json.dumps(shaped),
+                json_payload=shaped,
                 is_read=not silent,
             )
             self.db.update_request_status(req_id, "ok")
@@ -433,9 +433,7 @@ class URLProcessor:
                     logger.info("insights_generated_silently", extra={"cid": correlation_id})
 
                 try:
-                    self.db.update_summary_insights(
-                        req_id, json.dumps(insights, ensure_ascii=False)
-                    )
+                    self.db.update_summary_insights(req_id, insights)
                     logger.debug(
                         "insights_persisted", extra={"cid": correlation_id, "request_id": req_id}
                     )
@@ -559,19 +557,28 @@ class URLProcessor:
             return False
 
         payload = summary_row.get("json_payload")
-        if not payload:
+        if payload is None:
             logger.debug(
                 "cached_summary_empty_payload",
                 extra={"request_id": req_id, "cid": correlation_id},
             )
             return False
 
-        try:
-            shaped = json.loads(payload)
-        except json.JSONDecodeError:
+        if isinstance(payload, Mapping):
+            shaped = dict(payload)
+        elif isinstance(payload, str):
+            try:
+                shaped = json.loads(payload)
+            except json.JSONDecodeError:
+                logger.warning(
+                    "cached_summary_decode_failed",
+                    extra={"request_id": req_id, "cid": correlation_id},
+                )
+                return False
+        else:
             logger.warning(
-                "cached_summary_decode_failed",
-                extra={"request_id": req_id, "cid": correlation_id},
+                "cached_summary_unsupported_payload",
+                extra={"request_id": req_id, "cid": correlation_id, "type": type(payload).__name__},
             )
             return False
 
@@ -610,18 +617,28 @@ class URLProcessor:
             )
 
             insights_raw = summary_row.get("insights_json")
-            if isinstance(insights_raw, str) and insights_raw.strip():
+            insights_payload: dict[str, Any] | None
+            if isinstance(insights_raw, Mapping):
+                insights_payload = dict(cast(Mapping[str, Any], insights_raw))
+            elif isinstance(insights_raw, str) and insights_raw.strip():
                 try:
-                    insights_payload = json.loads(insights_raw)
-                    if isinstance(insights_payload, dict):
-                        await self.response_formatter.send_additional_insights_message(
-                            message, insights_payload, correlation_id
-                        )
+                    decoded = json.loads(insights_raw)
                 except json.JSONDecodeError:
                     logger.warning(
                         "cached_insights_decode_failed",
                         extra={"request_id": req_id, "cid": correlation_id},
                     )
+                    decoded = None
+                if isinstance(decoded, Mapping):
+                    insights_payload = dict(cast(Mapping[str, Any], decoded))
+                else:
+                    insights_payload = None
+            else:
+                insights_payload = None
+            if insights_payload:
+                await self.response_formatter.send_additional_insights_message(
+                    message, dict(insights_payload), correlation_id
+                )
 
         self.db.update_request_status(req_id, "ok")
 

--- a/app/adapters/openrouter/openrouter_client.py
+++ b/app/adapters/openrouter/openrouter_client.py
@@ -400,9 +400,11 @@ class OpenRouterClient:
                 f"Request timeout: {e}",
                 context={
                     "client": "shared" if client in self._client_pool.values() else "dedicated",
-                    "timeout_seconds": self._timeout.read_timeout
-                    if hasattr(self._timeout, "read_timeout")
-                    else "unknown",
+                    "timeout_seconds": (
+                        self._timeout.read_timeout
+                        if hasattr(self._timeout, "read_timeout")
+                        else "unknown"
+                    ),
                 },
             ) from e
         except httpx.ConnectError as e:
@@ -1120,9 +1122,9 @@ class OpenRouterClient:
                         "success": False,
                         "should_retry": True,
                         "new_rf_mode": new_mode,
-                        "new_response_format": {"type": "json_object"}
-                        if new_mode == "json_object"
-                        else None,
+                        "new_response_format": (
+                            {"type": "json_object"} if new_mode == "json_object" else None
+                        ),
                         "backoff_needed": True,
                     }
                 else:

--- a/app/adapters/telegram/forward_processor.py
+++ b/app/adapters/telegram/forward_processor.py
@@ -241,9 +241,7 @@ class ForwardProcessor:
                 logger.info("insights_message_sent_for_forward", extra={"cid": correlation_id})
 
                 try:
-                    self.db.update_summary_insights(
-                        req_id, json.dumps(insights, ensure_ascii=False)
-                    )
+                    self.db.update_summary_insights(req_id, insights)
                     logger.debug(
                         "insights_persisted_for_forward",
                         extra={"cid": correlation_id, "request_id": req_id},

--- a/app/adapters/telegram/forward_summarizer.py
+++ b/app/adapters/telegram/forward_summarizer.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
@@ -173,16 +172,15 @@ class ForwardSummarizer:
         """Handle LLM errors."""
         # persist LLM call as error, then reply
         try:
-            # json.dumps with default=str to avoid MagicMock serialization errors in tests
             self.db.insert_llm_call(
                 request_id=req_id,
                 provider="openrouter",
                 model=llm.model or self.cfg.openrouter.model,
                 endpoint=llm.endpoint,
-                request_headers_json=json.dumps(llm.request_headers or {}, default=str),
-                request_messages_json=json.dumps(llm.request_messages or [], default=str),
+                request_headers_json=llm.request_headers or {},
+                request_messages_json=list(llm.request_messages or []),
                 response_text=llm.response_text,
-                response_json=json.dumps(llm.response_json or {}, default=str),
+                response_json=llm.response_json or {},
                 tokens_prompt=llm.tokens_prompt,
                 tokens_completion=llm.tokens_completion,
                 cost_usd=llm.cost_usd,
@@ -192,7 +190,7 @@ class ForwardSummarizer:
                 structured_output_used=getattr(llm, "structured_output_used", None),
                 structured_output_mode=getattr(llm, "structured_output_mode", None),
                 error_context_json=(
-                    json.dumps(getattr(llm, "error_context", {}) or {}, default=str)
+                    getattr(llm, "error_context", {})
                     if getattr(llm, "error_context", None) is not None
                     else None
                 ),
@@ -381,10 +379,10 @@ class ForwardSummarizer:
                 provider="openrouter",
                 model=llm.model or self.cfg.openrouter.model,
                 endpoint=llm.endpoint,
-                request_headers_json=json.dumps(llm.request_headers or {}, default=str),
-                request_messages_json=json.dumps([m for m in messages], default=str),
+                request_headers_json=llm.request_headers or {},
+                request_messages_json=list(messages),
                 response_text=llm.response_text,
-                response_json=json.dumps(llm.response_json or {}, default=str),
+                response_json=llm.response_json or {},
                 tokens_prompt=llm.tokens_prompt,
                 tokens_completion=llm.tokens_completion,
                 cost_usd=llm.cost_usd,
@@ -394,7 +392,7 @@ class ForwardSummarizer:
                 structured_output_used=getattr(llm, "structured_output_used", None),
                 structured_output_mode=getattr(llm, "structured_output_mode", None),
                 error_context_json=(
-                    json.dumps(getattr(llm, "error_context", {}) or {}, default=str)
+                    getattr(llm, "error_context", {})
                     if getattr(llm, "error_context", None) is not None
                     else None
                 ),
@@ -406,7 +404,7 @@ class ForwardSummarizer:
             new_version = self.db.upsert_summary(
                 request_id=req_id,
                 lang=chosen_lang,
-                json_payload=json.dumps(forward_shaped),
+                json_payload=forward_shaped,
                 is_read=True,
             )
             self.db.update_request_status(req_id, "ok")

--- a/app/adapters/telegram/message_handler.py
+++ b/app/adapters/telegram/message_handler.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -76,8 +75,6 @@ class MessageHandler:
     def _audit(self, level: str, event: str, details: dict) -> None:
         """Audit log helper."""
         try:
-            self.db.insert_audit_log(
-                level=level, event=event, details_json=json.dumps(details, ensure_ascii=False)
-            )
+            self.db.insert_audit_log(level=level, event=event, details_json=details)
         except Exception as e:  # noqa: BLE001
             logger.error("audit_persist_failed", extra={"error": str(e), "event": event})

--- a/app/adapters/telegram/message_router.py
+++ b/app/adapters/telegram/message_router.py
@@ -1,4 +1,5 @@
 """Message routing and coordination for Telegram bot."""
+
 # ruff: noqa: E501
 # flake8: noqa
 
@@ -680,9 +681,11 @@ class MessageRouter:
                         "batch_result_debug",
                         extra={
                             "result_type": type(result).__name__,
-                            "result_value": str(result)[:200]
-                            if not isinstance(result, Exception)
-                            else str(result),
+                            "result_value": (
+                                str(result)[:200]
+                                if not isinstance(result, Exception)
+                                else str(result)
+                            ),
                             "is_tuple": isinstance(result, tuple),
                             "tuple_len": len(result) if isinstance(result, tuple) else 0,
                             "cid": correlation_id,

--- a/app/adapters/telegram/telegram_bot.py
+++ b/app/adapters/telegram/telegram_bot.py
@@ -184,9 +184,7 @@ class TelegramBot:
     def _audit(self, level: str, event: str, details: dict) -> None:
         """Audit log helper."""
         try:
-            self.db.insert_audit_log(
-                level=level, event=event, details_json=json.dumps(details, ensure_ascii=False)
-            )
+            self.db.insert_audit_log(level=level, event=event, details_json=details)
         except Exception as e:  # noqa: BLE001
             logger.error("audit_persist_failed", extra={"error": str(e), "event": event})
 

--- a/app/cli/summary.py
+++ b/app/cli/summary.py
@@ -264,11 +264,11 @@ def _build_audit(db: Database) -> Callable[[str, str, dict[str, Any]], None]:
 
     def audit(level: str, event: str, details: dict[str, Any]) -> None:
         try:
-            payload = json.dumps(details, ensure_ascii=False)
-        except TypeError:
-            payload = json.dumps({"details": str(details)}, ensure_ascii=False)
-
-        try:
+            payload: dict[str, Any]
+            if isinstance(details, dict):
+                payload = details
+            else:
+                payload = {"details": str(details)}
             db.insert_audit_log(level=level, event=event, details_json=payload)
         except Exception:  # noqa: BLE001 - audit failures should not crash CLI
             logger.exception("audit_log_failed", extra={"event": event})

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -6,6 +6,7 @@ import datetime as _dt
 from typing import Any
 
 import peewee
+from playhouse.sqlite_ext import JSONField
 
 # A proxy that will be initialised with the concrete database instance at runtime.
 database_proxy: peewee.Database = peewee.DatabaseProxy()
@@ -69,15 +70,15 @@ class TelegramMessage(BaseModel):
     chat_id = peewee.BigIntegerField(null=True)
     date_ts = peewee.IntegerField(null=True)
     text_full = peewee.TextField(null=True)
-    entities_json = peewee.TextField(null=True)
+    entities_json = JSONField(null=True)
     media_type = peewee.TextField(null=True)
-    media_file_ids_json = peewee.TextField(null=True)
+    media_file_ids_json = JSONField(null=True)
     forward_from_chat_id = peewee.BigIntegerField(null=True)
     forward_from_chat_type = peewee.TextField(null=True)
     forward_from_chat_title = peewee.TextField(null=True)
     forward_from_message_id = peewee.IntegerField(null=True)
     forward_date_ts = peewee.IntegerField(null=True)
-    telegram_raw_json = peewee.TextField(null=True)
+    telegram_raw_json = JSONField(null=True)
 
     class Meta:
         table_name = "telegram_messages"
@@ -91,19 +92,19 @@ class CrawlResult(BaseModel):
     endpoint = peewee.TextField(null=True)
     http_status = peewee.IntegerField(null=True)
     status = peewee.TextField(null=True)
-    options_json = peewee.TextField(null=True)
+    options_json = JSONField(null=True)
     correlation_id = peewee.TextField(null=True)
     content_markdown = peewee.TextField(null=True)
     content_html = peewee.TextField(null=True)
-    structured_json = peewee.TextField(null=True)
-    metadata_json = peewee.TextField(null=True)
-    links_json = peewee.TextField(null=True)
-    screenshots_paths_json = peewee.TextField(null=True)
+    structured_json = JSONField(null=True)
+    metadata_json = JSONField(null=True)
+    links_json = JSONField(null=True)
+    screenshots_paths_json = JSONField(null=True)
     firecrawl_success = peewee.BooleanField(null=True)
     firecrawl_error_code = peewee.TextField(null=True)
     firecrawl_error_message = peewee.TextField(null=True)
-    firecrawl_details_json = peewee.TextField(null=True)
-    raw_response_json = peewee.TextField(null=True)
+    firecrawl_details_json = JSONField(null=True)
+    raw_response_json = JSONField(null=True)
     latency_ms = peewee.IntegerField(null=True)
     error_text = peewee.TextField(null=True)
 
@@ -116,12 +117,12 @@ class LLMCall(BaseModel):
     provider = peewee.TextField(null=True)
     model = peewee.TextField(null=True)
     endpoint = peewee.TextField(null=True)
-    request_headers_json = peewee.TextField(null=True)
-    request_messages_json = peewee.TextField(null=True)
+    request_headers_json = JSONField(null=True)
+    request_messages_json = JSONField(null=True)
     response_text = peewee.TextField(null=True)
-    response_json = peewee.TextField(null=True)
+    response_json = JSONField(null=True)
     openrouter_response_text = peewee.TextField(null=True)
-    openrouter_response_json = peewee.TextField(null=True)
+    openrouter_response_json = JSONField(null=True)
     tokens_prompt = peewee.IntegerField(null=True)
     tokens_completion = peewee.IntegerField(null=True)
     cost_usd = peewee.FloatField(null=True)
@@ -130,7 +131,7 @@ class LLMCall(BaseModel):
     error_text = peewee.TextField(null=True)
     structured_output_used = peewee.BooleanField(null=True)
     structured_output_mode = peewee.TextField(null=True)
-    error_context_json = peewee.TextField(null=True)
+    error_context_json = JSONField(null=True)
     created_at = peewee.DateTimeField(default=_dt.datetime.utcnow)
 
     class Meta:
@@ -140,8 +141,8 @@ class LLMCall(BaseModel):
 class Summary(BaseModel):
     request = peewee.ForeignKeyField(Request, backref="summary", unique=True, on_delete="CASCADE")
     lang = peewee.TextField(null=True)
-    json_payload = peewee.TextField(null=True)
-    insights_json = peewee.TextField(null=True)
+    json_payload = JSONField(null=True)
+    insights_json = JSONField(null=True)
     version = peewee.IntegerField(default=1)
     is_read = peewee.BooleanField(default=False)
     created_at = peewee.DateTimeField(default=_dt.datetime.utcnow)
@@ -185,7 +186,7 @@ class AuditLog(BaseModel):
     ts = peewee.DateTimeField(default=_dt.datetime.utcnow)
     level = peewee.TextField()
     event = peewee.TextField()
-    details_json = peewee.TextField(null=True)
+    details_json = JSONField(null=True)
 
     class Meta:
         table_name = "audit_logs"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,4 +1,3 @@
-import json
 import os
 import tempfile
 import unittest
@@ -221,7 +220,7 @@ class TestCommands(unittest.IsolatedAsyncioTestCase):
             bot.db.insert_summary(
                 request_id=rid_good,
                 lang="en",
-                json_payload=json.dumps(base_summary),
+                json_payload=base_summary,
             )
             bot.db.insert_crawl_result(
                 request_id=rid_good,
@@ -229,13 +228,13 @@ class TestCommands(unittest.IsolatedAsyncioTestCase):
                 endpoint="/v1/scrape",
                 http_status=200,
                 status="ok",
-                options_json=json.dumps({}),
+                options_json={},
                 correlation_id="fc-good",
                 content_markdown="# md",
                 content_html=None,
-                structured_json=json.dumps({}),
-                metadata_json=json.dumps({}),
-                links_json=json.dumps(["https://example.com/other"]),
+                structured_json={},
+                metadata_json={},
+                links_json=["https://example.com/other"],
                 screenshots_paths_json=None,
                 firecrawl_success=True,
                 firecrawl_error_code=None,
@@ -263,7 +262,7 @@ class TestCommands(unittest.IsolatedAsyncioTestCase):
             bot.db.insert_summary(
                 request_id=rid_bad,
                 lang="en",
-                json_payload=json.dumps(bad_summary),
+                json_payload=bad_summary,
             )
 
             rid_empty = bot.db.create_request(
@@ -279,7 +278,7 @@ class TestCommands(unittest.IsolatedAsyncioTestCase):
             bot.db.insert_summary(
                 request_id=rid_empty,
                 lang="en",
-                json_payload=json.dumps(base_summary),
+                json_payload=base_summary,
             )
             bot.db.insert_crawl_result(
                 request_id=rid_empty,
@@ -287,13 +286,13 @@ class TestCommands(unittest.IsolatedAsyncioTestCase):
                 endpoint="/v1/scrape",
                 http_status=200,
                 status="ok",
-                options_json=json.dumps({}),
+                options_json={},
                 correlation_id="fc-empty",
                 content_markdown="# md",
                 content_html=None,
-                structured_json=json.dumps({}),
-                metadata_json=json.dumps({}),
-                links_json=json.dumps([]),
+                structured_json={},
+                metadata_json={},
+                links_json=[],
                 screenshots_paths_json=None,
                 firecrawl_success=True,
                 firecrawl_error_code=None,

--- a/tests/test_database_helpers.py
+++ b/tests/test_database_helpers.py
@@ -125,13 +125,13 @@ class TestDatabaseHelpers(unittest.TestCase):
             endpoint="/v1/scrape",
             http_status=200,
             status="ok",
-            options_json=json.dumps({}),
+            options_json={},
             correlation_id="fc-123",
             content_markdown="# md",
             content_html=None,
-            structured_json=json.dumps({}),
-            metadata_json=json.dumps({}),
-            links_json=json.dumps({}),
+            structured_json={},
+            metadata_json={},
+            links_json={},
             screenshots_paths_json=None,
             firecrawl_success=True,
             firecrawl_error_code=None,
@@ -147,7 +147,7 @@ class TestDatabaseHelpers(unittest.TestCase):
         self.assertEqual(row["http_status"], 200)
         self.assertEqual(row["content_markdown"], "# md")
         self.assertEqual(row["correlation_id"], "fc-123")
-        self.assertEqual(row["firecrawl_success"], 1)
+        self.assertTrue(row["firecrawl_success"])
         self.assertIsNone(row["raw_response_json"])
 
     def test_summary_upsert(self):
@@ -159,7 +159,7 @@ class TestDatabaseHelpers(unittest.TestCase):
             user_id=None,
             route_version=1,
         )
-        v1 = self.db.upsert_summary(request_id=rid, lang="en", json_payload=json.dumps({"a": 1}))
+        v1 = self.db.upsert_summary(request_id=rid, lang="en", json_payload={"a": 1})
         self.assertEqual(v1, 1)
         row = self.db.get_summary_by_request(rid)
         self.assertIsNotNone(row)
@@ -167,12 +167,12 @@ class TestDatabaseHelpers(unittest.TestCase):
         self.assertEqual(row["lang"], "en")
         self.assertIsNone(row["insights_json"])
 
-        v2 = self.db.upsert_summary(request_id=rid, lang="en", json_payload=json.dumps({"a": 2}))
+        v2 = self.db.upsert_summary(request_id=rid, lang="en", json_payload={"a": 2})
         self.assertEqual(v2, 2)
         row2 = self.db.get_summary_by_request(rid)
         self.assertEqual(row2["version"], 2)
 
-        insights_payload = json.dumps({"topic_overview": "Context", "new_facts": []})
+        insights_payload = {"topic_overview": "Context", "new_facts": []}
         self.db.update_summary_insights(rid, insights_payload)
         row3 = self.db.get_summary_by_request(rid)
         self.assertEqual(row3["insights_json"], insights_payload)
@@ -193,15 +193,15 @@ class TestDatabaseHelpers(unittest.TestCase):
             chat_id=1,
             date_ts=1700000000,
             text_full="hello",
-            entities_json=json.dumps([{"type": "bold"}]),
+            entities_json=[{"type": "bold"}],
             media_type="photo",
-            media_file_ids_json=json.dumps(["file_1"]),
+            media_file_ids_json=["file_1"],
             forward_from_chat_id=7,
             forward_from_chat_type="channel",
             forward_from_chat_title="Title",
             forward_from_message_id=5,
             forward_date_ts=1700000001,
-            telegram_raw_json=json.dumps({"k": "v"}),
+            telegram_raw_json={"k": "v"},
         )
         self.assertIsInstance(mid, int)
         row = self.db.fetchone("SELECT * FROM telegram_messages WHERE request_id = ?", (rid,))
@@ -215,10 +215,10 @@ class TestDatabaseHelpers(unittest.TestCase):
             provider="openrouter",
             model="m",
             endpoint="/api/v1/chat/completions",
-            request_headers_json=json.dumps({"Authorization": "REDACTED"}),
-            request_messages_json=json.dumps([{"role": "user", "content": "hi"}]),
+            request_headers_json={"Authorization": "REDACTED"},
+            request_messages_json=[{"role": "user", "content": "hi"}],
             response_text="{}",
-            response_json=json.dumps({"choices": []}),
+            response_json={"choices": []},
             tokens_prompt=1,
             tokens_completion=2,
             cost_usd=0.001,
@@ -227,7 +227,7 @@ class TestDatabaseHelpers(unittest.TestCase):
             error_text=None,
             structured_output_used=True,
             structured_output_mode="json_schema",
-            error_context_json=json.dumps({"status_code": 200}),
+            error_context_json={"status_code": 200},
         )
         self.assertIsInstance(lid, int)
         lrow = self.db.fetchone("SELECT * FROM llm_calls WHERE id = ?", (lid,))
@@ -246,9 +246,7 @@ class TestDatabaseHelpers(unittest.TestCase):
         )
 
         # Audit
-        aid = self.db.insert_audit_log(
-            level="INFO", event="test", details_json=json.dumps({"x": 1})
-        )
+        aid = self.db.insert_audit_log(level="INFO", event="test", details_json={"x": 1})
         self.assertIsInstance(aid, int)
         arow = self.db.fetchone("SELECT * FROM audit_logs WHERE id = ?", (aid,))
         self.assertIsNotNone(arow)
@@ -303,7 +301,7 @@ class TestDatabaseHelpers(unittest.TestCase):
         self.db.insert_summary(
             request_id=rid_good,
             lang="en",
-            json_payload=json.dumps(base_summary),
+            json_payload=base_summary,
         )
         self.db.insert_crawl_result(
             request_id=rid_good,
@@ -311,13 +309,13 @@ class TestDatabaseHelpers(unittest.TestCase):
             endpoint="/v1/scrape",
             http_status=200,
             status="ok",
-            options_json=json.dumps({}),
+            options_json={},
             correlation_id="fc-good",
             content_markdown="# md",
             content_html=None,
-            structured_json=json.dumps({}),
-            metadata_json=json.dumps({}),
-            links_json=json.dumps(["https://example.com/other"]),
+            structured_json={},
+            metadata_json={},
+            links_json=["https://example.com/other"],
             screenshots_paths_json=None,
             firecrawl_success=True,
             firecrawl_error_code=None,
@@ -347,7 +345,7 @@ class TestDatabaseHelpers(unittest.TestCase):
         self.db.insert_summary(
             request_id=rid_bad,
             lang="en",
-            json_payload=json.dumps(bad_summary),
+            json_payload=bad_summary,
         )
 
         rid_empty_links = self.db.create_request(
@@ -363,7 +361,7 @@ class TestDatabaseHelpers(unittest.TestCase):
         self.db.insert_summary(
             request_id=rid_empty_links,
             lang="en",
-            json_payload=json.dumps(base_summary),
+            json_payload=base_summary,
         )
         self.db.insert_crawl_result(
             request_id=rid_empty_links,
@@ -371,13 +369,13 @@ class TestDatabaseHelpers(unittest.TestCase):
             endpoint="/v1/scrape",
             http_status=200,
             status="ok",
-            options_json=json.dumps({}),
+            options_json={},
             correlation_id="fc-empty",
             content_markdown="# md",
             content_html=None,
-            structured_json=json.dumps({}),
-            metadata_json=json.dumps({}),
-            links_json=json.dumps([]),
+            structured_json={},
+            metadata_json={},
+            links_json=[],
             screenshots_paths_json=None,
             firecrawl_success=True,
             firecrawl_error_code=None,
@@ -466,15 +464,15 @@ class TestDatabaseHelpers(unittest.TestCase):
             chat_id=1,
             date_ts=1700000000,
             text_full="hello",
-            entities_json=json.dumps([{"type": "bold"}]),
+            entities_json=[{"type": "bold"}],
             media_type="photo",
-            media_file_ids_json=json.dumps(["file_a"]),
+            media_file_ids_json=["file_a"],
             forward_from_chat_id=None,
             forward_from_chat_type=None,
             forward_from_chat_title=None,
             forward_from_message_id=None,
             forward_date_ts=None,
-            telegram_raw_json=json.dumps({"k": "v"}),
+            telegram_raw_json={"k": "v"},
         )
 
         mid2 = self.db.insert_telegram_message(
@@ -483,15 +481,15 @@ class TestDatabaseHelpers(unittest.TestCase):
             chat_id=1,
             date_ts=1700000000,
             text_full="hello",
-            entities_json=json.dumps([{"type": "bold"}]),
+            entities_json=[{"type": "bold"}],
             media_type="video",
-            media_file_ids_json=json.dumps(["file_b"]),
+            media_file_ids_json=["file_b"],
             forward_from_chat_id=None,
             forward_from_chat_type=None,
             forward_from_chat_title=None,
             forward_from_message_id=None,
             forward_date_ts=None,
-            telegram_raw_json=json.dumps({"k": "v"}),
+            telegram_raw_json={"k": "v"},
         )
 
         self.assertEqual(mid1, mid2)

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -106,13 +106,13 @@ class TestDedupeReuse(unittest.IsolatedAsyncioTestCase):
                 endpoint="/v1/scrape",
                 http_status=200,
                 status="ok",
-                options_json=json.dumps({"formats": ["markdown"], "mobile": True}),
+                options_json={"formats": ["markdown"], "mobile": True},
                 correlation_id="firecrawl-cid",
                 content_markdown="# cached",
                 content_html=None,
-                structured_json=json.dumps({}),
-                metadata_json=json.dumps({}),
-                links_json=json.dumps({}),
+                structured_json={},
+                metadata_json={},
+                links_json={},
                 screenshots_paths_json=None,
                 firecrawl_success=True,
                 firecrawl_error_code=None,
@@ -206,7 +206,7 @@ class TestDedupeReuse(unittest.IsolatedAsyncioTestCase):
             db.insert_summary(
                 request_id=req_id,
                 lang="en",
-                json_payload=json.dumps({"summary_250": "cached", "tldr": "cached"}),
+                json_payload={"summary_250": "cached", "tldr": "cached"},
             )
 
             cfg = AppConfig(

--- a/tests/test_read_status.py
+++ b/tests/test_read_status.py
@@ -1,4 +1,3 @@
-import json
 import os
 import tempfile
 import unittest
@@ -51,13 +50,13 @@ class ReadStatusBot(TelegramBot):
                     self.http_status = 200
                     self.endpoint = "https://api.firecrawl.dev/v1/scrape"
                     self.error_text = None
-                    self.options_json = '{"formats": ["markdown"]}'
+                    self.options_json = {"formats": ["markdown"]}
                     self.correlation_id = None
                     self.content_markdown = "Mock content"
                     self.content_html = "Mock HTML"
-                    self.structured_json = "{}"
-                    self.metadata_json = "{}"  # Add missing attribute
-                    self.links_json = "[]"  # Add missing attribute
+                    self.structured_json = {}
+                    self.metadata_json = {}  # Add missing attribute
+                    self.links_json = []  # Add missing attribute
                     self.screenshots_paths_json = None  # Add missing attribute
                     self.response_success = True
                     self.response_error_code = None
@@ -126,7 +125,7 @@ class TestReadStatusDatabase(unittest.TestCase):
         self.db.insert_summary(
             request_id=rid,
             lang="en",
-            json_payload=json.dumps({"title": "Test Article"}),
+            json_payload={"title": "Test Article"},
         )
 
         row = self.db.get_summary_by_request(rid)
@@ -156,7 +155,7 @@ class TestReadStatusDatabase(unittest.TestCase):
         self.db.insert_summary(
             request_id=rid1,
             lang="en",
-            json_payload=json.dumps({"title": "Unread Article"}),
+            json_payload={"title": "Unread Article"},
             is_read=False,
         )
 
@@ -164,7 +163,7 @@ class TestReadStatusDatabase(unittest.TestCase):
         self.db.insert_summary(
             request_id=rid2,
             lang="en",
-            json_payload=json.dumps({"title": "Read Article"}),
+            json_payload={"title": "Read Article"},
             is_read=True,
         )
 
@@ -209,19 +208,19 @@ class TestReadStatusDatabase(unittest.TestCase):
         self.db.insert_summary(
             request_id=rid1,
             lang="en",
-            json_payload=json.dumps({"title": "Article 1"}),
+            json_payload={"title": "Article 1"},
             is_read=False,
         )
         self.db.insert_summary(
             request_id=rid2,
             lang="en",
-            json_payload=json.dumps({"title": "Article 2"}),
+            json_payload={"title": "Article 2"},
             is_read=True,
         )
         self.db.insert_summary(
             request_id=rid3,
             lang="en",
-            json_payload=json.dumps({"title": "Article 3"}),
+            json_payload={"title": "Article 3"},
             is_read=False,
         )
 
@@ -247,7 +246,7 @@ class TestReadStatusDatabase(unittest.TestCase):
             self.db.insert_summary(
                 request_id=rid,
                 lang="en",
-                json_payload=json.dumps({"title": f"Article {i}"}),
+                json_payload={"title": f"Article {i}"},
                 is_read=False,
             )
 
@@ -269,7 +268,7 @@ class TestReadStatusDatabase(unittest.TestCase):
         self.db.insert_summary(
             request_id=rid,
             lang="en",
-            json_payload=json.dumps({"title": "Test Article"}),
+            json_payload={"title": "Test Article"},
             is_read=False,
         )
 
@@ -306,13 +305,13 @@ class TestReadStatusDatabase(unittest.TestCase):
         self.db.insert_summary(
             request_id=rid1,
             lang="en",
-            json_payload=json.dumps({"title": "Unread Article"}),
+            json_payload={"title": "Unread Article"},
             is_read=False,
         )
         self.db.insert_summary(
             request_id=rid2,
             lang="en",
-            json_payload=json.dumps({"title": "Read Article"}),
+            json_payload={"title": "Read Article"},
             is_read=True,
         )
 
@@ -335,7 +334,7 @@ class TestReadStatusDatabase(unittest.TestCase):
         self.db.insert_summary(
             request_id=rid,
             lang="en",
-            json_payload=json.dumps({"title": "Test Article"}),
+            json_payload={"title": "Test Article"},
             is_read=False,
         )
 
@@ -384,9 +383,10 @@ class TestReadStatusCommands(unittest.IsolatedAsyncioTestCase):
                 bot.db.insert_summary(
                     request_id=rid,
                     lang="en",
-                    json_payload=json.dumps(
-                        {"title": f"Article {i + 1}", "metadata": {"title": f"Article {i + 1}"}}
-                    ),
+                    json_payload={
+                        "title": f"Article {i + 1}",
+                        "metadata": {"title": f"Article {i + 1}"},
+                    },
                     is_read=False,
                 )
 
@@ -443,13 +443,11 @@ class TestReadStatusCommands(unittest.IsolatedAsyncioTestCase):
             bot.db.insert_summary(
                 request_id=rid,
                 lang="en",
-                json_payload=json.dumps(
-                    {
-                        "title": "Test Article",
-                        "summary_250": "This is a test article.",
-                        "metadata": {"title": "Test Article"},
-                    }
-                ),
+                json_payload={
+                    "title": "Test Article",
+                    "summary_250": "This is a test article.",
+                    "metadata": {"title": "Test Article"},
+                },
                 is_read=False,
             )
 
@@ -483,9 +481,7 @@ class TestReadStatusCommands(unittest.IsolatedAsyncioTestCase):
             bot.db.insert_summary(
                 request_id=rid,
                 lang="en",
-                json_payload=json.dumps(
-                    {"title": "Test Article", "metadata": {"title": "Test Article"}}
-                ),
+                json_payload={"title": "Test Article", "metadata": {"title": "Test Article"}},
                 is_read=True,  # Already read
             )
 
@@ -537,7 +533,7 @@ class TestReadStatusIntegration(unittest.IsolatedAsyncioTestCase):
             bot.db.insert_summary(
                 request_id=rid,
                 lang="en",
-                json_payload=json.dumps({"title": "Test Article"}),
+                json_payload={"title": "Test Article"},
                 is_read=False,
             )
 


### PR DESCRIPTION
## Summary
- migrate all JSON-bearing Peewee columns to `JSONField` and update database helpers to work with native dict/list inputs, including schema coercion during migration
- update content, OpenRouter, and Telegram adapters plus CLI entry points to stop pre-dumping JSON strings and operate on decoded payloads end-to-end
- refresh persistence-related unit tests to reflect the new JSON workflow and cover the normalization helpers

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68da5988def8832c8d43fab699b11cb6