### PR TITLE
Add async database wrappers and update asynchronous flows

### DIFF
--- a/app/adapters/content/content_extractor.py
+++ b/app/adapters/content/content_extractor.py
@@ -133,7 +133,7 @@ class ContentExtractor:
         """Handle request deduplication or creation."""
         self._upsert_sender_metadata(message)
 
-        existing_req = self.db.get_request_by_dedupe_hash(dedupe)
+        existing_req = await self.db.async_get_request_by_dedupe_hash(dedupe)
 
         if existing_req:
             req_id = int(existing_req["id"])  # reuse existing request
@@ -246,7 +246,7 @@ class ContentExtractor:
         silent: bool = False,
     ) -> tuple[str, str]:
         """Extract content from Firecrawl or reuse existing crawl result."""
-        existing_crawl = self.db.get_crawl_result_by_request(req_id)
+        existing_crawl = await self.db.async_get_crawl_result_by_request(req_id)
 
         if existing_crawl and (
             existing_crawl.get("content_markdown") or existing_crawl.get("content_html")
@@ -618,7 +618,7 @@ class ContentExtractor:
         silent: bool = False,
     ) -> None:
         """Handle Firecrawl extraction errors."""
-        self.db.update_request_status(req_id, "error")
+        await self.db.async_update_request_status(req_id, "error")
         # Provide a precise, user-visible stage and context
         detail_lines = []
         url_line = crawl.source_url or "unknown"

--- a/app/adapters/telegram/access_controller.py
+++ b/app/adapters/telegram/access_controller.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from app.config import AppConfig
 from app.db.database import Database
-from app.db.user_interactions import safe_update_user_interaction
+from app.db.user_interactions import async_safe_update_user_interaction
 
 if TYPE_CHECKING:
     from app.adapters.external.response_formatter import ResponseFormatter
@@ -125,7 +125,7 @@ class AccessController:
         logger.info("access_denied", extra={"uid": uid, "cid": correlation_id})
 
         if interaction_id:
-            safe_update_user_interaction(
+            await async_safe_update_user_interaction(
                 self.db,
                 interaction_id=interaction_id,
                 response_sent=True,

--- a/app/adapters/telegram/command_processor.py
+++ b/app/adapters/telegram/command_processor.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 from app.config import AppConfig
 from app.core.logging_utils import generate_correlation_id
 from app.core.url_utils import extract_all_urls
-from app.db.user_interactions import safe_update_user_interaction
+from app.db.user_interactions import async_safe_update_user_interaction
 
 if TYPE_CHECKING:
     from app.adapters.content.url_processor import URLProcessor
@@ -62,7 +62,7 @@ class CommandProcessor:
 
         await self.response_formatter.send_welcome(message)
         if interaction_id:
-            safe_update_user_interaction(
+            await async_safe_update_user_interaction(
                 self.db,
                 interaction_id=interaction_id,
                 response_sent=True,
@@ -89,7 +89,7 @@ class CommandProcessor:
 
         await self.response_formatter.send_help(message)
         if interaction_id:
-            safe_update_user_interaction(
+            await async_safe_update_user_interaction(
                 self.db,
                 interaction_id=interaction_id,
                 response_sent=True,
@@ -123,7 +123,7 @@ class CommandProcessor:
                 "⚠️ Unable to read database overview right now. Check bot logs for details.",
             )
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,
@@ -137,7 +137,7 @@ class CommandProcessor:
 
         await self.response_formatter.send_db_overview(message, overview)
         if interaction_id:
-            safe_update_user_interaction(
+            await async_safe_update_user_interaction(
                 self.db,
                 interaction_id=interaction_id,
                 response_sent=True,
@@ -171,7 +171,7 @@ class CommandProcessor:
                 "⚠️ Unable to verify database records right now. Check bot logs for details.",
             )
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,
@@ -258,7 +258,7 @@ class CommandProcessor:
                 )
 
         if interaction_id:
-            safe_update_user_interaction(
+            await async_safe_update_user_interaction(
                 self.db,
                 interaction_id=interaction_id,
                 response_sent=True,
@@ -284,7 +284,7 @@ class CommandProcessor:
                 "Send multiple URLs in one message after /summarize_all, separated by space or new line.",
             )
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,
@@ -317,7 +317,7 @@ class CommandProcessor:
 
         await self.response_formatter.safe_reply(message, f"Processing {len(urls)} links...")
         if interaction_id:
-            safe_update_user_interaction(
+            await async_safe_update_user_interaction(
                 self.db,
                 interaction_id=interaction_id,
                 response_sent=True,
@@ -374,7 +374,7 @@ class CommandProcessor:
             )
             logger.debug("awaiting_multi_confirm", extra={"uid": uid, "count": len(urls)})
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,
@@ -395,7 +395,7 @@ class CommandProcessor:
             await self.response_formatter.safe_reply(message, "Send a URL to summarize.")
             logger.debug("awaiting_url", extra={"uid": uid})
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,
@@ -452,7 +452,7 @@ class CommandProcessor:
             response_type = (
                 "cancelled" if (awaiting_cancelled or multi_cancelled) else "cancel_none"
             )
-            safe_update_user_interaction(
+            await async_safe_update_user_interaction(
                 self.db,
                 interaction_id=interaction_id,
                 response_sent=True,
@@ -516,7 +516,7 @@ class CommandProcessor:
             await self.response_formatter.safe_reply(message, "\n".join(response_lines))
 
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,
@@ -532,7 +532,7 @@ class CommandProcessor:
                 "⚠️ Unable to retrieve unread articles right now. Check bot logs for details.",
             )
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,
@@ -639,7 +639,7 @@ class CommandProcessor:
                     )
 
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,
@@ -656,7 +656,7 @@ class CommandProcessor:
                 "⚠️ Unable to read the article right now. Check bot logs for details.",
             )
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,

--- a/app/adapters/telegram/message_router.py
+++ b/app/adapters/telegram/message_router.py
@@ -15,7 +15,7 @@ from app.config import AppConfig
 from app.core.logging_utils import generate_correlation_id
 from app.core.url_utils import extract_all_urls, looks_like_url
 from app.db.database import Database
-from app.db.user_interactions import safe_update_user_interaction
+from app.db.user_interactions import async_safe_update_user_interaction
 from app.models.telegram.telegram_models import TelegramMessage
 
 if TYPE_CHECKING:
@@ -167,7 +167,7 @@ class MessageRouter:
                 f"An unexpected error occurred. Error ID: {correlation_id}. Please try again.",
             )
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,
@@ -293,7 +293,7 @@ class MessageRouter:
             },
         )
         if interaction_id:
-            safe_update_user_interaction(
+            await async_safe_update_user_interaction(
                 self.db,
                 interaction_id=interaction_id,
                 response_sent=True,
@@ -858,7 +858,7 @@ class MessageRouter:
         )
 
         if interaction_id:
-            safe_update_user_interaction(
+            await async_safe_update_user_interaction(
                 self.db,
                 interaction_id=interaction_id,
                 response_sent=True,

--- a/app/adapters/telegram/url_handler.py
+++ b/app/adapters/telegram/url_handler.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 from app.core.logging_utils import generate_correlation_id
 from app.core.url_utils import extract_all_urls
 from app.db.database import Database
-from app.db.user_interactions import safe_update_user_interaction
+from app.db.user_interactions import async_safe_update_user_interaction
 
 if TYPE_CHECKING:
     from app.adapters.content.url_processor import URLProcessor
@@ -169,7 +169,7 @@ class URLHandler:
                     "ℹ️ No pending multi-link request to confirm. Please send the links again.",
                 )
                 if interaction_id:
-                    safe_update_user_interaction(
+                    await async_safe_update_user_interaction(
                         self.db,
                         interaction_id=interaction_id,
                         response_sent=True,
@@ -200,7 +200,7 @@ class URLHandler:
                     "❌ Pending multi-link request is invalid. Please send the links again.",
                 )
                 if interaction_id:
-                    safe_update_user_interaction(
+                    await async_safe_update_user_interaction(
                         self.db,
                         interaction_id=interaction_id,
                         response_sent=True,
@@ -218,7 +218,7 @@ class URLHandler:
                 message, f"🚀 Processing {len(urls)} links in parallel..."
             )
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,
@@ -235,7 +235,7 @@ class URLHandler:
             self._pending_multi_links.pop(uid, None)
             await self.response_formatter.safe_reply(message, "Cancelled.")
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,
@@ -275,7 +275,7 @@ class URLHandler:
         await self.response_formatter.safe_reply(message, f"Process {len(urls)} links? (yes/no)")
         logger.debug("awaiting_multi_confirm", extra={"uid": uid, "count": len(urls)})
         if interaction_id:
-            safe_update_user_interaction(
+            await async_safe_update_user_interaction(
                 self.db,
                 interaction_id=interaction_id,
                 response_sent=True,

--- a/tests/test_content_quality.py
+++ b/tests/test_content_quality.py
@@ -60,6 +60,7 @@ def _firecrawl_result(markdown: str | None, html: str | None) -> FirecrawlResult
 @pytest.mark.asyncio
 async def test_low_value_content_triggers_failure() -> None:
     db = MagicMock()
+    db.async_update_request_status = AsyncMock()
     response_formatter = MagicMock()
     response_formatter.send_firecrawl_start_notification = AsyncMock()
     response_formatter.send_error_notification = AsyncMock()
@@ -85,7 +86,7 @@ async def test_low_value_content_triggers_failure() -> None:
         )
 
     assert "insufficient_useful_content" in str(exc_info.value)
-    db.update_request_status.assert_called_with(42, "error")
+    db.async_update_request_status.assert_awaited_once_with(42, "error")
     response_formatter.send_error_notification.assert_awaited()
     response_formatter.send_firecrawl_success_notification.assert_not_awaited()
 

--- a/tests/test_json_parsing.py
+++ b/tests/test_json_parsing.py
@@ -54,6 +54,12 @@ class TestJsonParsing(unittest.TestCase):
 
         self.cfg = AppConfig(telegram_cfg, firecrawl_cfg, openrouter_cfg, runtime_cfg)
         self.db = MagicMock(spec=Database)
+        self.db.async_get_request_by_dedupe_hash = AsyncMock(return_value=None)
+        self.db.async_get_crawl_result_by_request = AsyncMock(return_value=None)
+        self.db.async_get_summary_by_request = AsyncMock(return_value=None)
+        self.db.async_upsert_summary = AsyncMock(return_value=1)
+        self.db.async_update_request_status = AsyncMock()
+        self.db.async_insert_llm_call = AsyncMock()
 
     def _make_insights_response(self) -> MagicMock:
         payload = {
@@ -114,11 +120,13 @@ class TestJsonParsing(unittest.TestCase):
 
             bot._safe_reply = AsyncMock()  # type: ignore[method-assign]
             bot._reply_json = AsyncMock()  # type: ignore[method-assign]
-            self.db.get_request_by_dedupe_hash.return_value = None
+            self.db.async_get_request_by_dedupe_hash.return_value = None
             self.db.create_request.return_value = 1
-            self.db.get_crawl_result_by_request.return_value = {"content_markdown": "Some content"}
-            self.db.get_summary_by_request.return_value = None
-            self.db.upsert_summary.return_value = 1
+            self.db.async_get_crawl_result_by_request.return_value = {
+                "content_markdown": "Some content"
+            }
+            self.db.async_get_summary_by_request.return_value = None
+            self.db.async_upsert_summary.return_value = 1
 
             message = MagicMock()
             await bot._handle_url_flow(message, "http://example.com")
@@ -143,10 +151,12 @@ class TestJsonParsing(unittest.TestCase):
             bot._openrouter = mock_openrouter_instance
 
             bot._safe_reply = AsyncMock()  # type: ignore[method-assign]
-            self.db.get_request_by_dedupe_hash.return_value = None
+            self.db.async_get_request_by_dedupe_hash.return_value = None
             self.db.create_request.return_value = 1
-            self.db.get_crawl_result_by_request.return_value = {"content_markdown": "Some content"}
-            self.db.get_summary_by_request.return_value = None
+            self.db.async_get_crawl_result_by_request.return_value = {
+                "content_markdown": "Some content"
+            }
+            self.db.async_get_summary_by_request.return_value = None
 
             message = MagicMock()
             await bot._handle_url_flow(message, "http://example.com")
@@ -186,11 +196,13 @@ class TestJsonParsing(unittest.TestCase):
 
             bot._safe_reply = AsyncMock()  # type: ignore[method-assign]
             bot._reply_json = AsyncMock()  # type: ignore[method-assign]
-            self.db.get_request_by_dedupe_hash.return_value = None
+            self.db.async_get_request_by_dedupe_hash.return_value = None
             self.db.create_request.return_value = 1
-            self.db.get_crawl_result_by_request.return_value = {"content_markdown": "Some content"}
-            self.db.get_summary_by_request.return_value = None
-            self.db.upsert_summary.return_value = 1
+            self.db.async_get_crawl_result_by_request.return_value = {
+                "content_markdown": "Some content"
+            }
+            self.db.async_get_summary_by_request.return_value = None
+            self.db.async_upsert_summary.return_value = 1
 
             message = MagicMock()
             await bot._handle_url_flow(message, "http://example.com")
@@ -236,11 +248,13 @@ class TestJsonParsing(unittest.TestCase):
 
             bot._safe_reply = AsyncMock()  # type: ignore[method-assign]
             bot._reply_json = AsyncMock()  # type: ignore[method-assign]
-            self.db.get_request_by_dedupe_hash.return_value = None
+            self.db.async_get_request_by_dedupe_hash.return_value = None
             self.db.create_request.return_value = 1
-            self.db.get_crawl_result_by_request.return_value = {"content_markdown": "Some content"}
-            self.db.get_summary_by_request.return_value = None
-            self.db.upsert_summary.return_value = 1
+            self.db.async_get_crawl_result_by_request.return_value = {
+                "content_markdown": "Some content"
+            }
+            self.db.async_get_summary_by_request.return_value = None
+            self.db.async_upsert_summary.return_value = 1
 
             message = MagicMock()
             await bot._handle_url_flow(message, "http://example.com")
@@ -290,8 +304,8 @@ class TestJsonParsing(unittest.TestCase):
             bot._reply_json = AsyncMock()  # type: ignore[method-assign]
 
             self.db.create_request.return_value = 1
-            self.db.upsert_summary.return_value = 1
-            self.db.get_summary_by_request.return_value = None
+            self.db.async_upsert_summary.return_value = 1
+            self.db.async_get_summary_by_request.return_value = None
 
             message = MagicMock()
             message.text = "Some forwarded text"


### PR DESCRIPTION
## Summary
- add asyncio-backed wrappers in the database layer for common read/write helpers
- refactor summarizer and telegram adapter flows to await the new async database helpers and the async-safe interaction updater
- extend user interaction utilities and tests to cover the async helper and update mocks to patch the new async database API

## Testing
- ruff check . --fix
- ruff format .
- mypy .
- pytest *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68da60720648832cad230179e06af9a1