### PR TITLE
Refactor summarization workflows to shared helper

### DIFF
--- a/app/adapters/content/content_extractor.py
+++ b/app/adapters/content/content_extractor.py
@@ -133,7 +133,7 @@ class ContentExtractor:
         """Handle request deduplication or creation."""
         self._upsert_sender_metadata(message)
 
-        existing_req = self.db.get_request_by_dedupe_hash(dedupe)
+        existing_req = await self.db.async_get_request_by_dedupe_hash(dedupe)
 
         if existing_req:
             req_id = int(existing_req["id"])  # reuse existing request
@@ -246,7 +246,7 @@ class ContentExtractor:
         silent: bool = False,
     ) -> tuple[str, str]:
         """Extract content from Firecrawl or reuse existing crawl result."""
-        existing_crawl = self.db.get_crawl_result_by_request(req_id)
+        existing_crawl = await self.db.async_get_crawl_result_by_request(req_id)
 
         if existing_crawl and (
             existing_crawl.get("content_markdown") or existing_crawl.get("content_html")
@@ -618,7 +618,7 @@ class ContentExtractor:
         silent: bool = False,
     ) -> None:
         """Handle Firecrawl extraction errors."""
-        self.db.update_request_status(req_id, "error")
+        await self.db.async_update_request_status(req_id, "error")
         # Provide a precise, user-visible stage and context
         detail_lines = []
         url_line = crawl.source_url or "unknown"

--- a/app/adapters/content/llm_response_workflow.py
+++ b/app/adapters/content/llm_response_workflow.py
@@ -1,0 +1,624 @@
+"""Reusable workflow helper for handling LLM summary responses."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from app.core.json_utils import extract_json
+from app.core.summary_contract import validate_and_shape_summary
+from app.db.database import Database
+from app.db.user_interactions import safe_update_user_interaction
+from app.utils.json_validation import finalize_summary_texts, parse_summary_response
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class LLMRequestConfig:
+    """Configuration for a single LLM attempt."""
+
+    messages: list[dict[str, Any]]
+    response_format: dict[str, Any]
+    max_tokens: int | None
+    temperature: float | None
+    top_p: float | None
+    model_override: str | None = None
+    silent: bool = False
+
+
+@dataclass(slots=True)
+class LLMRepairContext:
+    """Context required to attempt JSON repair prompts."""
+
+    base_messages: list[dict[str, Any]]
+    repair_response_format: dict[str, Any]
+    repair_max_tokens: int | None
+    default_prompt: str
+    missing_fields_prompt: str | None = None
+
+
+@dataclass(slots=True)
+class LLMWorkflowNotifications:
+    """Notification callbacks invoked during workflow progression."""
+
+    completion: Callable[[Any, LLMRequestConfig], Awaitable[None]] | None = None
+    llm_error: Callable[[Any, str | None], Awaitable[None]] | None = None
+    repair_failure: Callable[[], Awaitable[None]] | None = None
+    parsing_failure: Callable[[], Awaitable[None]] | None = None
+
+
+@dataclass(slots=True)
+class LLMInteractionConfig:
+    """Settings for updating user interactions."""
+
+    interaction_id: int | None
+    success_kwargs: dict[str, Any] | None = None
+    llm_error_builder: Callable[[Any, str | None], dict[str, Any]] | None = None
+    repair_failure_kwargs: dict[str, Any] | None = None
+    parsing_failure_kwargs: dict[str, Any] | None = None
+
+
+@dataclass(slots=True)
+class LLMSummaryPersistenceSettings:
+    """Configuration for persisting summary results."""
+
+    lang: str
+    is_read: bool = True
+    insights_getter: Callable[[dict[str, Any]], dict[str, Any] | None] | None = None
+
+
+class LLMResponseWorkflow:
+    """Reusable helper encapsulating shared LLM response automation."""
+
+    def __init__(
+        self,
+        *,
+        cfg: Any,
+        db: Database,
+        openrouter: Any,
+        response_formatter: Any,
+        audit_func: Callable[[str, str, dict[str, Any]], None],
+        sem: Callable[[], Any],
+    ) -> None:
+        self.cfg = cfg
+        self.db = db
+        self.openrouter = openrouter
+        self.response_formatter = response_formatter
+        self._audit = audit_func
+        self._sem = sem
+
+    async def execute_summary_workflow(
+        self,
+        *,
+        message: Any,
+        req_id: int,
+        correlation_id: str | None,
+        interaction_config: LLMInteractionConfig,
+        persistence: LLMSummaryPersistenceSettings,
+        repair_context: LLMRepairContext,
+        requests: Sequence[LLMRequestConfig],
+        notifications: LLMWorkflowNotifications | None = None,
+        ensure_summary: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
+        on_attempt: Callable[[Any], Awaitable[None]] | None = None,
+        on_success: Callable[[dict[str, Any], Any], Awaitable[None]] | None = None,
+        required_summary_fields: Sequence[str] = ("tldr", "summary_250", "summary_1000"),
+    ) -> dict[str, Any] | None:
+        """Run the shared summary processing workflow for a sequence of attempts."""
+
+        if not requests:
+            raise ValueError("requests must include at least one attempt")
+
+        for attempt in requests:
+            llm = await self._invoke_llm(attempt, req_id)
+
+            if on_attempt is not None:
+                await on_attempt(llm)
+
+            self.schedule_persist_llm_call(llm, req_id, correlation_id)
+
+            if notifications and notifications.completion:
+                await notifications.completion(llm, attempt)
+
+            summary = await self._process_attempt(
+                message=message,
+                llm=llm,
+                req_id=req_id,
+                correlation_id=correlation_id,
+                interaction_config=interaction_config,
+                persistence=persistence,
+                repair_context=repair_context,
+                request_config=attempt,
+                notifications=notifications,
+                ensure_summary=ensure_summary,
+                on_success=on_success,
+                required_summary_fields=required_summary_fields,
+            )
+
+            if summary is not None:
+                return summary
+
+        await self._handle_parsing_failure(
+            message,
+            req_id,
+            correlation_id,
+            interaction_config,
+            notifications,
+        )
+        return None
+
+    def build_structured_response_format(self, mode: str | None = None) -> dict[str, Any]:
+        """Build response format configuration for structured outputs."""
+        try:
+            from app.core.summary_contract import get_summary_json_schema
+
+            current_mode = mode or self.cfg.openrouter.structured_output_mode
+
+            if current_mode == "json_schema":
+                return {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "summary_schema",
+                        "schema": get_summary_json_schema(),
+                        "strict": True,
+                    },
+                }
+            return {"type": "json_object"}
+        except Exception:
+            return {"type": "json_object"}
+
+    def schedule_persist_llm_call(
+        self, llm: Any, req_id: int, correlation_id: str | None
+    ) -> asyncio.Task[Any]:
+        """Persist an LLM call asynchronously."""
+
+        return asyncio.create_task(self._persist_llm_call(llm, req_id, correlation_id))
+
+    async def _invoke_llm(self, request: LLMRequestConfig, req_id: int) -> Any:
+        async with self._sem():
+            return await self.openrouter.chat(
+                request.messages,
+                temperature=request.temperature,
+                max_tokens=request.max_tokens,
+                top_p=request.top_p,
+                request_id=req_id,
+                response_format=request.response_format,
+                model_override=request.model_override,
+            )
+
+    async def _process_attempt(
+        self,
+        *,
+        message: Any,
+        llm: Any,
+        req_id: int,
+        correlation_id: str | None,
+        interaction_config: LLMInteractionConfig,
+        persistence: LLMSummaryPersistenceSettings,
+        repair_context: LLMRepairContext,
+        request_config: LLMRequestConfig,
+        notifications: LLMWorkflowNotifications | None,
+        ensure_summary: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]] | None,
+        on_success: Callable[[dict[str, Any], Any], Awaitable[None]] | None,
+        required_summary_fields: Sequence[str],
+    ) -> dict[str, Any] | None:
+        if llm.status != "ok":
+            salvage = None
+            if (llm.error_text or "") == "structured_output_parse_error":
+                salvage = await self._attempt_salvage_parsing(llm, correlation_id)
+            if salvage is not None:
+                return await self._finalize_success(
+                    salvage,
+                    llm,
+                    req_id,
+                    correlation_id,
+                    interaction_config,
+                    persistence,
+                    ensure_summary,
+                    on_success,
+                )
+
+            await self._handle_llm_error(
+                message,
+                llm,
+                req_id,
+                correlation_id,
+                interaction_config,
+                notifications,
+            )
+            return None
+
+        parse_result = parse_summary_response(llm.response_json, llm.response_text)
+        shaped = parse_result.shaped if parse_result else None
+
+        if shaped is None:
+            shaped = await self._attempt_json_repair(
+                message,
+                llm,
+                req_id,
+                correlation_id,
+                interaction_config,
+                repair_context,
+                request_config,
+                notifications,
+                parse_result=parse_result,
+            )
+
+        if shaped is None:
+            return None
+
+        finalize_summary_texts(shaped)
+
+        if not self._summary_has_content(shaped, required_summary_fields):
+            logger.warning(
+                "summary_fields_empty",
+                extra={"cid": correlation_id, "stage": "attempt"},
+            )
+            return None
+
+        return await self._finalize_success(
+            shaped,
+            llm,
+            req_id,
+            correlation_id,
+            interaction_config,
+            persistence,
+            ensure_summary,
+            on_success,
+        )
+
+    async def _finalize_success(
+        self,
+        summary: dict[str, Any],
+        llm: Any,
+        req_id: int,
+        correlation_id: str | None,
+        interaction_config: LLMInteractionConfig,
+        persistence: LLMSummaryPersistenceSettings,
+        ensure_summary: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]] | None,
+        on_success: Callable[[dict[str, Any], Any], Awaitable[None]] | None,
+    ) -> dict[str, Any]:
+        if ensure_summary is not None:
+            summary = await ensure_summary(summary)
+
+        finalize_summary_texts(summary)
+
+        if on_success is not None:
+            await on_success(summary, llm)
+
+        insights_json: dict[str, Any] | None = None
+        if persistence.insights_getter is not None:
+            try:
+                insights_json = persistence.insights_getter(summary)
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "insights_getter_failed",
+                    extra={"cid": correlation_id, "error": str(exc)},
+                )
+
+        try:
+            new_version = self.db.upsert_summary(
+                request_id=req_id,
+                lang=persistence.lang,
+                json_payload=summary,
+                insights_json=insights_json,
+                is_read=persistence.is_read,
+            )
+            self.db.update_request_status(req_id, "ok")
+            self._audit("INFO", "summary_upserted", {"request_id": req_id, "version": new_version})
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "persist_summary_error",
+                extra={"error": str(exc), "cid": correlation_id},
+            )
+
+        if interaction_config.interaction_id and interaction_config.success_kwargs:
+            try:
+                safe_update_user_interaction(
+                    self.db,
+                    interaction_id=interaction_config.interaction_id,
+                    logger_=logger,
+                    **interaction_config.success_kwargs,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "interaction_success_update_failed",
+                    extra={"cid": correlation_id, "error": str(exc)},
+                )
+
+        logger.info(
+            "llm_finished_enhanced",
+            extra={
+                "status": llm.status,
+                "latency_ms": llm.latency_ms,
+                "model": llm.model,
+                "cid": correlation_id,
+                "summary_250_len": len(summary.get("summary_250", "")),
+                "tldr_len": len(summary.get("tldr", "") or summary.get("summary_1000", "")),
+                "key_ideas_count": len(summary.get("key_ideas", [])),
+                "topic_tags_count": len(summary.get("topic_tags", [])),
+                "entities_count": len(summary.get("entities", [])),
+                "reading_time_min": summary.get("estimated_reading_time_min"),
+                "seo_keywords_count": len(summary.get("seo_keywords", [])),
+                "structured_output_used": getattr(llm, "structured_output_used", False),
+                "structured_output_mode": getattr(llm, "structured_output_mode", None),
+            },
+        )
+
+        return summary
+
+    async def _attempt_salvage_parsing(
+        self, llm: Any, correlation_id: str | None
+    ) -> dict[str, Any] | None:
+        try:
+            parsed = extract_json(llm.response_text or "")
+            if isinstance(parsed, dict):
+                shaped = validate_and_shape_summary(parsed)
+                finalize_summary_texts(shaped)
+                if shaped:
+                    return shaped
+
+            parse_result = parse_summary_response(llm.response_json, llm.response_text)
+            shaped = parse_result.shaped if parse_result else None
+            if shaped:
+                finalize_summary_texts(shaped)
+                logger.info(
+                    "structured_output_salvage_success",
+                    extra={"cid": correlation_id},
+                )
+                return shaped
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "salvage_error",
+                extra={"error": str(exc), "cid": correlation_id},
+            )
+        return None
+
+    async def _attempt_json_repair(
+        self,
+        message: Any,
+        llm: Any,
+        req_id: int,
+        correlation_id: str | None,
+        interaction_config: LLMInteractionConfig,
+        repair_context: LLMRepairContext,
+        request_config: LLMRequestConfig,
+        notifications: LLMWorkflowNotifications | None,
+        *,
+        parse_result: Any,
+    ) -> dict[str, Any] | None:
+        try:
+            logger.info(
+                "json_repair_attempt_enhanced",
+                extra={
+                    "cid": correlation_id,
+                    "reason": (
+                        parse_result.errors[-3:] if parse_result and parse_result.errors else None
+                    ),
+                    "structured_mode": self.cfg.openrouter.structured_output_mode,
+                },
+            )
+
+            repair_messages = list(repair_context.base_messages)
+            repair_messages.append({"role": "assistant", "content": llm.response_text or ""})
+
+            if (
+                parse_result
+                and parse_result.errors
+                and "missing_summary_fields" in parse_result.errors
+            ):
+                prompt = repair_context.missing_fields_prompt or repair_context.default_prompt
+            else:
+                prompt = repair_context.default_prompt
+
+            repair_messages.append({"role": "user", "content": prompt})
+
+            async with self._sem():
+                repair = await self.openrouter.chat(
+                    repair_messages,
+                    temperature=request_config.temperature,
+                    max_tokens=repair_context.repair_max_tokens,
+                    top_p=request_config.top_p,
+                    request_id=req_id,
+                    response_format=repair_context.repair_response_format,
+                    model_override=request_config.model_override,
+                )
+
+            if repair.status == "ok":
+                repair_result = parse_summary_response(repair.response_json, repair.response_text)
+                if repair_result.shaped is not None:
+                    finalize_summary_texts(repair_result.shaped)
+                    logger.info(
+                        "json_repair_success_enhanced",
+                        extra={
+                            "cid": correlation_id,
+                            "used_local_fix": repair_result.used_local_fix,
+                        },
+                    )
+                    return repair_result.shaped
+                raise ValueError("repair_failed")
+            raise ValueError("repair_call_error")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "json_repair_failed",
+                extra={"cid": correlation_id, "error": str(exc)},
+            )
+            await self._handle_repair_failure(
+                message,
+                req_id,
+                correlation_id,
+                interaction_config,
+                notifications,
+            )
+            return None
+
+    async def _handle_llm_error(
+        self,
+        message: Any,
+        llm: Any,
+        req_id: int,
+        correlation_id: str | None,
+        interaction_config: LLMInteractionConfig,
+        notifications: LLMWorkflowNotifications | None,
+    ) -> None:
+        self.db.update_request_status(req_id, "error")
+
+        error_parts: list[str] = []
+        context = getattr(llm, "error_context", None) or {}
+
+        status_code = context.get("status_code") if isinstance(context, dict) else None
+        if status_code is not None:
+            error_parts.append(f"HTTP {status_code}")
+
+        message_text = context.get("message") if isinstance(context, dict) else None
+        if message_text:
+            error_parts.append(str(message_text))
+
+        api_error = context.get("api_error") if isinstance(context, dict) else None
+        if api_error and api_error not in error_parts:
+            error_parts.append(str(api_error))
+
+        provider = context.get("provider") if isinstance(context, dict) else None
+        if provider:
+            error_parts.append(f"Provider: {provider}")
+
+        if llm.error_text and llm.error_text not in error_parts:
+            error_parts.append(str(llm.error_text))
+
+        error_details = " | ".join(error_parts) if error_parts else None
+
+        logger.error(
+            "openrouter_error",
+            extra={"error": llm.error_text, "cid": correlation_id},
+        )
+
+        try:
+            self._audit(
+                "ERROR",
+                "openrouter_error",
+                {"request_id": req_id, "cid": correlation_id, "error": llm.error_text},
+            )
+        except Exception:
+            pass
+
+        if notifications and notifications.llm_error:
+            try:
+                await notifications.llm_error(llm, error_details)
+            except Exception:
+                pass
+
+        if interaction_config.interaction_id and interaction_config.llm_error_builder:
+            try:
+                kwargs = interaction_config.llm_error_builder(llm, error_details)
+                safe_update_user_interaction(
+                    self.db,
+                    interaction_id=interaction_config.interaction_id,
+                    logger_=logger,
+                    **kwargs,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "interaction_error_update_failed",
+                    extra={"cid": correlation_id, "error": str(exc)},
+                )
+
+    async def _handle_repair_failure(
+        self,
+        message: Any,
+        req_id: int,
+        correlation_id: str | None,
+        interaction_config: LLMInteractionConfig,
+        notifications: LLMWorkflowNotifications | None,
+    ) -> None:
+        self.db.update_request_status(req_id, "error")
+
+        if notifications and notifications.repair_failure:
+            try:
+                await notifications.repair_failure()
+            except Exception:
+                pass
+
+        if interaction_config.interaction_id and interaction_config.repair_failure_kwargs:
+            try:
+                safe_update_user_interaction(
+                    self.db,
+                    interaction_id=interaction_config.interaction_id,
+                    logger_=logger,
+                    **interaction_config.repair_failure_kwargs,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "interaction_repair_update_failed",
+                    extra={"cid": correlation_id, "error": str(exc)},
+                )
+
+    async def _handle_parsing_failure(
+        self,
+        message: Any,
+        req_id: int,
+        correlation_id: str | None,
+        interaction_config: LLMInteractionConfig,
+        notifications: LLMWorkflowNotifications | None,
+    ) -> None:
+        self.db.update_request_status(req_id, "error")
+
+        if notifications and notifications.parsing_failure:
+            try:
+                await notifications.parsing_failure()
+            except Exception:
+                pass
+
+        if interaction_config.interaction_id and interaction_config.parsing_failure_kwargs:
+            try:
+                safe_update_user_interaction(
+                    self.db,
+                    interaction_id=interaction_config.interaction_id,
+                    logger_=logger,
+                    **interaction_config.parsing_failure_kwargs,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "interaction_parsing_update_failed",
+                    extra={"cid": correlation_id, "error": str(exc)},
+                )
+
+    def _summary_has_content(self, summary: dict[str, Any], required_fields: Sequence[str]) -> bool:
+        for field in required_fields:
+            value = summary.get(field)
+            if isinstance(value, str) and value.strip():
+                return True
+        return False
+
+    async def _persist_llm_call(self, llm: Any, req_id: int, correlation_id: str | None) -> None:
+        try:
+            self.db.insert_llm_call(
+                request_id=req_id,
+                provider="openrouter",
+                model=llm.model or self.cfg.openrouter.model,
+                endpoint=llm.endpoint,
+                request_headers_json=llm.request_headers or {},
+                request_messages_json=list(llm.request_messages or []),
+                response_text=llm.response_text,
+                response_json=llm.response_json or {},
+                tokens_prompt=llm.tokens_prompt,
+                tokens_completion=llm.tokens_completion,
+                cost_usd=llm.cost_usd,
+                latency_ms=llm.latency_ms,
+                status=llm.status,
+                error_text=llm.error_text,
+                structured_output_used=getattr(llm, "structured_output_used", None),
+                structured_output_mode=getattr(llm, "structured_output_mode", None),
+                error_context_json=(
+                    getattr(llm, "error_context", {})
+                    if getattr(llm, "error_context", None) is not None
+                    else None
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "persist_llm_error",
+                extra={"error": str(exc), "cid": correlation_id},
+            )

--- a/app/adapters/telegram/access_controller.py
+++ b/app/adapters/telegram/access_controller.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from app.config import AppConfig
 from app.db.database import Database
-from app.db.user_interactions import safe_update_user_interaction
+from app.db.user_interactions import async_safe_update_user_interaction
 
 if TYPE_CHECKING:
     from app.adapters.external.response_formatter import ResponseFormatter
@@ -125,7 +125,7 @@ class AccessController:
         logger.info("access_denied", extra={"uid": uid, "cid": correlation_id})
 
         if interaction_id:
-            safe_update_user_interaction(
+            await async_safe_update_user_interaction(
                 self.db,
                 interaction_id=interaction_id,
                 response_sent=True,

--- a/app/adapters/telegram/command_processor.py
+++ b/app/adapters/telegram/command_processor.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 from app.config import AppConfig
 from app.core.logging_utils import generate_correlation_id
 from app.core.url_utils import extract_all_urls
-from app.db.user_interactions import safe_update_user_interaction
+from app.db.user_interactions import async_safe_update_user_interaction
 
 if TYPE_CHECKING:
     from app.adapters.content.url_processor import URLProcessor
@@ -62,7 +62,7 @@ class CommandProcessor:
 
         await self.response_formatter.send_welcome(message)
         if interaction_id:
-            safe_update_user_interaction(
+            await async_safe_update_user_interaction(
                 self.db,
                 interaction_id=interaction_id,
                 response_sent=True,
@@ -89,7 +89,7 @@ class CommandProcessor:
 
         await self.response_formatter.send_help(message)
         if interaction_id:
-            safe_update_user_interaction(
+            await async_safe_update_user_interaction(
                 self.db,
                 interaction_id=interaction_id,
                 response_sent=True,
@@ -123,7 +123,7 @@ class CommandProcessor:
                 "⚠️ Unable to read database overview right now. Check bot logs for details.",
             )
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,
@@ -137,7 +137,7 @@ class CommandProcessor:
 
         await self.response_formatter.send_db_overview(message, overview)
         if interaction_id:
-            safe_update_user_interaction(
+            await async_safe_update_user_interaction(
                 self.db,
                 interaction_id=interaction_id,
                 response_sent=True,
@@ -171,7 +171,7 @@ class CommandProcessor:
                 "⚠️ Unable to verify database records right now. Check bot logs for details.",
             )
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,
@@ -258,7 +258,7 @@ class CommandProcessor:
                 )
 
         if interaction_id:
-            safe_update_user_interaction(
+            await async_safe_update_user_interaction(
                 self.db,
                 interaction_id=interaction_id,
                 response_sent=True,
@@ -284,7 +284,7 @@ class CommandProcessor:
                 "Send multiple URLs in one message after /summarize_all, separated by space or new line.",
             )
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,
@@ -317,7 +317,7 @@ class CommandProcessor:
 
         await self.response_formatter.safe_reply(message, f"Processing {len(urls)} links...")
         if interaction_id:
-            safe_update_user_interaction(
+            await async_safe_update_user_interaction(
                 self.db,
                 interaction_id=interaction_id,
                 response_sent=True,
@@ -374,7 +374,7 @@ class CommandProcessor:
             )
             logger.debug("awaiting_multi_confirm", extra={"uid": uid, "count": len(urls)})
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,
@@ -395,7 +395,7 @@ class CommandProcessor:
             await self.response_formatter.safe_reply(message, "Send a URL to summarize.")
             logger.debug("awaiting_url", extra={"uid": uid})
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,
@@ -452,7 +452,7 @@ class CommandProcessor:
             response_type = (
                 "cancelled" if (awaiting_cancelled or multi_cancelled) else "cancel_none"
             )
-            safe_update_user_interaction(
+            await async_safe_update_user_interaction(
                 self.db,
                 interaction_id=interaction_id,
                 response_sent=True,
@@ -516,7 +516,7 @@ class CommandProcessor:
             await self.response_formatter.safe_reply(message, "\n".join(response_lines))
 
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,
@@ -532,7 +532,7 @@ class CommandProcessor:
                 "⚠️ Unable to retrieve unread articles right now. Check bot logs for details.",
             )
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,
@@ -639,7 +639,7 @@ class CommandProcessor:
                     )
 
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,
@@ -656,7 +656,7 @@ class CommandProcessor:
                 "⚠️ Unable to read the article right now. Check bot logs for details.",
             )
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,

--- a/app/adapters/telegram/message_router.py
+++ b/app/adapters/telegram/message_router.py
@@ -15,7 +15,7 @@ from app.config import AppConfig
 from app.core.logging_utils import generate_correlation_id
 from app.core.url_utils import extract_all_urls, looks_like_url
 from app.db.database import Database
-from app.db.user_interactions import safe_update_user_interaction
+from app.db.user_interactions import async_safe_update_user_interaction
 from app.models.telegram.telegram_models import TelegramMessage
 
 if TYPE_CHECKING:
@@ -167,7 +167,7 @@ class MessageRouter:
                 f"An unexpected error occurred. Error ID: {correlation_id}. Please try again.",
             )
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,
@@ -293,7 +293,7 @@ class MessageRouter:
             },
         )
         if interaction_id:
-            safe_update_user_interaction(
+            await async_safe_update_user_interaction(
                 self.db,
                 interaction_id=interaction_id,
                 response_sent=True,
@@ -858,7 +858,7 @@ class MessageRouter:
         )
 
         if interaction_id:
-            safe_update_user_interaction(
+            await async_safe_update_user_interaction(
                 self.db,
                 interaction_id=interaction_id,
                 response_sent=True,

--- a/app/adapters/telegram/url_handler.py
+++ b/app/adapters/telegram/url_handler.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 from app.core.logging_utils import generate_correlation_id
 from app.core.url_utils import extract_all_urls
 from app.db.database import Database
-from app.db.user_interactions import safe_update_user_interaction
+from app.db.user_interactions import async_safe_update_user_interaction
 
 if TYPE_CHECKING:
     from app.adapters.content.url_processor import URLProcessor
@@ -169,7 +169,7 @@ class URLHandler:
                     "ℹ️ No pending multi-link request to confirm. Please send the links again.",
                 )
                 if interaction_id:
-                    safe_update_user_interaction(
+                    await async_safe_update_user_interaction(
                         self.db,
                         interaction_id=interaction_id,
                         response_sent=True,
@@ -200,7 +200,7 @@ class URLHandler:
                     "❌ Pending multi-link request is invalid. Please send the links again.",
                 )
                 if interaction_id:
-                    safe_update_user_interaction(
+                    await async_safe_update_user_interaction(
                         self.db,
                         interaction_id=interaction_id,
                         response_sent=True,
@@ -218,7 +218,7 @@ class URLHandler:
                 message, f"🚀 Processing {len(urls)} links in parallel..."
             )
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,
@@ -235,7 +235,7 @@ class URLHandler:
             self._pending_multi_links.pop(uid, None)
             await self.response_formatter.safe_reply(message, "Cancelled.")
             if interaction_id:
-                safe_update_user_interaction(
+                await async_safe_update_user_interaction(
                     self.db,
                     interaction_id=interaction_id,
                     response_sent=True,
@@ -275,7 +275,7 @@ class URLHandler:
         await self.response_formatter.safe_reply(message, f"Process {len(urls)} links? (yes/no)")
         logger.debug("awaiting_multi_confirm", extra={"uid": uid, "count": len(urls)})
         if interaction_id:
-            safe_update_user_interaction(
+            await async_safe_update_user_interaction(
                 self.db,
                 interaction_id=interaction_id,
                 response_sent=True,

--- a/tests/test_content_quality.py
+++ b/tests/test_content_quality.py
@@ -60,6 +60,7 @@ def _firecrawl_result(markdown: str | None, html: str | None) -> FirecrawlResult
 @pytest.mark.asyncio
 async def test_low_value_content_triggers_failure() -> None:
     db = MagicMock()
+    db.async_update_request_status = AsyncMock()
     response_formatter = MagicMock()
     response_formatter.send_firecrawl_start_notification = AsyncMock()
     response_formatter.send_error_notification = AsyncMock()
@@ -85,7 +86,7 @@ async def test_low_value_content_triggers_failure() -> None:
         )
 
     assert "insufficient_useful_content" in str(exc_info.value)
-    db.update_request_status.assert_called_with(42, "error")
+    db.async_update_request_status.assert_awaited_once_with(42, "error")
     response_formatter.send_error_notification.assert_awaited()
     response_formatter.send_firecrawl_success_notification.assert_not_awaited()
 

--- a/tests/test_forward_summarizer.py
+++ b/tests/test_forward_summarizer.py
@@ -1,0 +1,78 @@
+import sys
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.modules.setdefault("pydantic", MagicMock())
+sys.modules.setdefault("pydantic_settings", MagicMock())
+sys.modules.setdefault("peewee", MagicMock())
+sys.modules.setdefault("playhouse", MagicMock())
+sys.modules.setdefault("playhouse.sqlite_ext", MagicMock())
+
+from app.adapters.telegram.forward_summarizer import ForwardSummarizer  # noqa: E402
+
+
+class ForwardSummarizerTests(unittest.IsolatedAsyncioTestCase):
+    class _Sem:
+        async def __aenter__(self) -> None:
+            return None
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    async def test_summarize_forward_delegates_to_workflow(self) -> None:
+        cfg = MagicMock()
+        cfg.openrouter.temperature = 0.2
+        cfg.openrouter.top_p = 1.0
+        cfg.openrouter.model = "primary"
+        cfg.openrouter.fallback_models = ()
+        cfg.openrouter.structured_output_mode = "json_object"
+
+        db = MagicMock()
+        openrouter = MagicMock()
+        response_formatter = MagicMock()
+
+        summarizer = ForwardSummarizer(
+            cfg,
+            db,
+            openrouter,
+            response_formatter,
+            lambda *a, **k: None,
+            lambda: self._Sem(),
+        )
+
+        mock_workflow = AsyncMock(return_value={"summary_250": "ok", "tldr": "fine"})
+
+        prompt = "Forward message"
+        message = MagicMock()
+
+        with patch.object(
+            summarizer._workflow,
+            "execute_summary_workflow",
+            new=mock_workflow,
+        ):
+            result = await summarizer.summarize_forward(
+                message=message,
+                prompt=prompt,
+                chosen_lang="en",
+                system_prompt="sys",
+                req_id=42,
+                correlation_id="cid",
+                interaction_id=99,
+            )
+
+        self.assertEqual(result, {"summary_250": "ok", "tldr": "fine"})
+        mock_workflow.assert_awaited_once()
+
+        call_kwargs = mock_workflow.call_args.kwargs
+        requests = call_kwargs["requests"]
+        self.assertEqual(len(requests), 1)
+        expected_tokens = max(2048, min(6144, len(prompt) // 4 + 2048))
+        self.assertEqual(requests[0].max_tokens, expected_tokens)
+
+        repair_context = call_kwargs["repair_context"]
+        self.assertEqual(repair_context.repair_max_tokens, expected_tokens)
+        self.assertIn("Summarize the following", repair_context.base_messages[1]["content"])
+
+        notifications = call_kwargs["notifications"]
+        self.assertIsNotNone(notifications.completion)
+        self.assertIsNotNone(notifications.llm_error)

--- a/tests/test_json_parsing.py
+++ b/tests/test_json_parsing.py
@@ -54,6 +54,12 @@ class TestJsonParsing(unittest.TestCase):
 
         self.cfg = AppConfig(telegram_cfg, firecrawl_cfg, openrouter_cfg, runtime_cfg)
         self.db = MagicMock(spec=Database)
+        self.db.async_get_request_by_dedupe_hash = AsyncMock(return_value=None)
+        self.db.async_get_crawl_result_by_request = AsyncMock(return_value=None)
+        self.db.async_get_summary_by_request = AsyncMock(return_value=None)
+        self.db.async_upsert_summary = AsyncMock(return_value=1)
+        self.db.async_update_request_status = AsyncMock()
+        self.db.async_insert_llm_call = AsyncMock()
 
     def _make_insights_response(self) -> MagicMock:
         payload = {
@@ -114,11 +120,13 @@ class TestJsonParsing(unittest.TestCase):
 
             bot._safe_reply = AsyncMock()  # type: ignore[method-assign]
             bot._reply_json = AsyncMock()  # type: ignore[method-assign]
-            self.db.get_request_by_dedupe_hash.return_value = None
+            self.db.async_get_request_by_dedupe_hash.return_value = None
             self.db.create_request.return_value = 1
-            self.db.get_crawl_result_by_request.return_value = {"content_markdown": "Some content"}
-            self.db.get_summary_by_request.return_value = None
-            self.db.upsert_summary.return_value = 1
+            self.db.async_get_crawl_result_by_request.return_value = {
+                "content_markdown": "Some content"
+            }
+            self.db.async_get_summary_by_request.return_value = None
+            self.db.async_upsert_summary.return_value = 1
 
             message = MagicMock()
             await bot._handle_url_flow(message, "http://example.com")
@@ -143,10 +151,12 @@ class TestJsonParsing(unittest.TestCase):
             bot._openrouter = mock_openrouter_instance
 
             bot._safe_reply = AsyncMock()  # type: ignore[method-assign]
-            self.db.get_request_by_dedupe_hash.return_value = None
+            self.db.async_get_request_by_dedupe_hash.return_value = None
             self.db.create_request.return_value = 1
-            self.db.get_crawl_result_by_request.return_value = {"content_markdown": "Some content"}
-            self.db.get_summary_by_request.return_value = None
+            self.db.async_get_crawl_result_by_request.return_value = {
+                "content_markdown": "Some content"
+            }
+            self.db.async_get_summary_by_request.return_value = None
 
             message = MagicMock()
             await bot._handle_url_flow(message, "http://example.com")
@@ -186,11 +196,13 @@ class TestJsonParsing(unittest.TestCase):
 
             bot._safe_reply = AsyncMock()  # type: ignore[method-assign]
             bot._reply_json = AsyncMock()  # type: ignore[method-assign]
-            self.db.get_request_by_dedupe_hash.return_value = None
+            self.db.async_get_request_by_dedupe_hash.return_value = None
             self.db.create_request.return_value = 1
-            self.db.get_crawl_result_by_request.return_value = {"content_markdown": "Some content"}
-            self.db.get_summary_by_request.return_value = None
-            self.db.upsert_summary.return_value = 1
+            self.db.async_get_crawl_result_by_request.return_value = {
+                "content_markdown": "Some content"
+            }
+            self.db.async_get_summary_by_request.return_value = None
+            self.db.async_upsert_summary.return_value = 1
 
             message = MagicMock()
             await bot._handle_url_flow(message, "http://example.com")
@@ -236,11 +248,13 @@ class TestJsonParsing(unittest.TestCase):
 
             bot._safe_reply = AsyncMock()  # type: ignore[method-assign]
             bot._reply_json = AsyncMock()  # type: ignore[method-assign]
-            self.db.get_request_by_dedupe_hash.return_value = None
+            self.db.async_get_request_by_dedupe_hash.return_value = None
             self.db.create_request.return_value = 1
-            self.db.get_crawl_result_by_request.return_value = {"content_markdown": "Some content"}
-            self.db.get_summary_by_request.return_value = None
-            self.db.upsert_summary.return_value = 1
+            self.db.async_get_crawl_result_by_request.return_value = {
+                "content_markdown": "Some content"
+            }
+            self.db.async_get_summary_by_request.return_value = None
+            self.db.async_upsert_summary.return_value = 1
 
             message = MagicMock()
             await bot._handle_url_flow(message, "http://example.com")
@@ -290,8 +304,8 @@ class TestJsonParsing(unittest.TestCase):
             bot._reply_json = AsyncMock()  # type: ignore[method-assign]
 
             self.db.create_request.return_value = 1
-            self.db.upsert_summary.return_value = 1
-            self.db.get_summary_by_request.return_value = None
+            self.db.async_upsert_summary.return_value = 1
+            self.db.async_get_summary_by_request.return_value = None
 
             message = MagicMock()
             message.text = "Some forwarded text"

--- a/tests/test_llm_response_workflow.py
+++ b/tests/test_llm_response_workflow.py
@@ -1,0 +1,217 @@
+import asyncio
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+sys.modules.setdefault("pydantic", MagicMock())
+sys.modules.setdefault("pydantic_settings", MagicMock())
+sys.modules.setdefault("peewee", MagicMock())
+sys.modules.setdefault("playhouse", MagicMock())
+sys.modules.setdefault("playhouse.sqlite_ext", MagicMock())
+
+from app.adapters.content.llm_response_workflow import (  # noqa: E402
+    LLMInteractionConfig,
+    LLMRepairContext,
+    LLMRequestConfig,
+    LLMResponseWorkflow,
+    LLMSummaryPersistenceSettings,
+    LLMWorkflowNotifications,
+)
+
+
+class _DummySemaphore:
+    async def __aenter__(self) -> None:  # noqa: D401 - simple semaphore
+        return None
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # noqa: D401 - simple semaphore
+        return None
+
+
+class LLMResponseWorkflowTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.cfg = MagicMock()
+        self.cfg.openrouter.model = "test-model"
+        self.cfg.openrouter.fallback_models = ()
+        self.cfg.openrouter.temperature = 0.1
+        self.cfg.openrouter.top_p = 1.0
+        self.cfg.openrouter.max_tokens = 4096
+        self.cfg.openrouter.structured_output_mode = "json_object"
+
+        self.db = MagicMock()
+        self.db.upsert_summary = MagicMock(return_value=1)
+        self.db.update_request_status = MagicMock()
+        self.db.insert_llm_call = MagicMock()
+
+        self.response_formatter = MagicMock()
+        self.openrouter = MagicMock()
+
+        self.workflow = LLMResponseWorkflow(
+            cfg=self.cfg,
+            db=self.db,
+            openrouter=self.openrouter,
+            response_formatter=self.response_formatter,
+            audit_func=lambda *args, **kwargs: None,
+            sem=lambda: _DummySemaphore(),
+        )
+
+        self.base_messages = [
+            {"role": "system", "content": "System"},
+            {"role": "user", "content": "Please summarise"},
+        ]
+
+        self.request = LLMRequestConfig(
+            messages=self.base_messages,
+            response_format={"type": "json_object"},
+            max_tokens=256,
+            temperature=0.1,
+            top_p=1.0,
+        )
+
+        self.repair_context = LLMRepairContext(
+            base_messages=self.base_messages,
+            repair_response_format={"type": "json_object"},
+            repair_max_tokens=256,
+            default_prompt="Repair",
+        )
+
+        self.completion_mock = AsyncMock()
+        self.llm_error_mock = AsyncMock()
+        self.repair_failure_mock = AsyncMock()
+        self.parsing_failure_mock = AsyncMock()
+
+        self.notifications = LLMWorkflowNotifications(
+            completion=self.completion_mock,
+            llm_error=self.llm_error_mock,
+            repair_failure=self.repair_failure_mock,
+            parsing_failure=self.parsing_failure_mock,
+        )
+
+        self.interaction = LLMInteractionConfig(interaction_id=None)
+        self.persistence = LLMSummaryPersistenceSettings(lang="en", is_read=True)
+
+    async def test_execute_success_persists_summary(self) -> None:
+        summary_payload = {
+            "summary_250": "Summary body",
+            "tldr": "TLDR text",
+        }
+        llm_response = self._llm_response(summary_payload)
+        self.openrouter.chat = AsyncMock(return_value=llm_response)
+
+        with unittest.mock.patch(
+            "app.adapters.content.llm_response_workflow.parse_summary_response",
+            return_value=SimpleNamespace(
+                shaped={"summary_250": "Summary body", "tldr": "TLDR text"},
+                errors=[],
+                used_local_fix=False,
+            ),
+        ):
+            summary = await self.workflow.execute_summary_workflow(
+                message=MagicMock(),
+                req_id=101,
+                correlation_id="cid",
+                interaction_config=self.interaction,
+                persistence=self.persistence,
+                repair_context=self.repair_context,
+                requests=[self.request],
+                notifications=self.notifications,
+            )
+
+        await asyncio.sleep(0)
+
+        self.assertIsNotNone(summary)
+        self.db.upsert_summary.assert_called_once()
+        _args, kwargs = self.db.upsert_summary.call_args
+        self.assertEqual(kwargs["request_id"], 101)
+        self.assertEqual(kwargs["lang"], "en")
+        self.db.update_request_status.assert_called_once_with(101, "ok")
+        self.completion_mock.assert_awaited_once()
+        self.llm_error_mock.assert_not_awaited()
+
+    async def test_execute_runs_repair_on_parse_failure(self) -> None:
+        llm_invalid = self._llm_response({}, text="not json")
+        llm_repaired = self._llm_response({}, text='{"summary_250": "Fixed", "tldr": "TLDR"}')
+        self.openrouter.chat = AsyncMock(side_effect=[llm_invalid, llm_repaired])
+
+        with unittest.mock.patch(
+            "app.adapters.content.llm_response_workflow.parse_summary_response",
+            side_effect=[
+                SimpleNamespace(shaped=None, errors=["invalid"], used_local_fix=False),
+                SimpleNamespace(
+                    shaped={"summary_250": "Fixed", "tldr": "TLDR"},
+                    errors=[],
+                    used_local_fix=False,
+                ),
+            ],
+        ):
+            summary = await self.workflow.execute_summary_workflow(
+                message=MagicMock(),
+                req_id=202,
+                correlation_id="repair",
+                interaction_config=self.interaction,
+                persistence=self.persistence,
+                repair_context=self.repair_context,
+                requests=[self.request],
+                notifications=self.notifications,
+            )
+
+        await asyncio.sleep(0)
+
+        self.assertIsNotNone(summary)
+        self.assertEqual(self.openrouter.chat.await_count, 2)
+        self.repair_failure_mock.assert_not_awaited()
+        self.db.upsert_summary.assert_called_once()
+
+    async def test_execute_handles_llm_error(self) -> None:
+        llm_error = self._llm_response({}, status="error", error_text="boom", text=None)
+        self.openrouter.chat = AsyncMock(return_value=llm_error)
+
+        summary = await self.workflow.execute_summary_workflow(
+            message=MagicMock(),
+            req_id=303,
+            correlation_id="err",
+            interaction_config=self.interaction,
+            persistence=self.persistence,
+            repair_context=self.repair_context,
+            requests=[self.request],
+            notifications=self.notifications,
+        )
+
+        await asyncio.sleep(0)
+
+        self.assertIsNone(summary)
+        self.db.upsert_summary.assert_not_called()
+        self.db.update_request_status.assert_called_with(303, "error")
+        self.llm_error_mock.assert_awaited_once()
+
+    def _llm_response(
+        self,
+        payload: dict[str, str],
+        *,
+        status: str = "ok",
+        error_text: str | None = None,
+        text: str | None = None,
+    ) -> SimpleNamespace:
+        response_text = text or self._to_json(payload)
+        return SimpleNamespace(
+            status=status,
+            response_json=payload,
+            response_text=response_text,
+            model="test-model",
+            endpoint="/chat",
+            request_headers={},
+            request_messages=self.base_messages,
+            tokens_prompt=50,
+            tokens_completion=25,
+            cost_usd=0.01,
+            latency_ms=120,
+            error_text=error_text,
+            structured_output_used=True,
+            structured_output_mode="json_object",
+            error_context=None,
+        )
+
+    @staticmethod
+    def _to_json(payload: dict[str, str]) -> str:
+        items = ", ".join(f'"{k}": "{v}"' for k, v in payload.items())
+        return "{" + items + "}"


### PR DESCRIPTION
## Summary
- add a shared `LLMResponseWorkflow` helper that unifies structured-output retries, auditing, and persistence logic
- refactor `LLMSummarizer` and `ForwardSummarizer` to delegate orchestration to the new helper and remove duplicated code
- add focused tests for the helper and forward summarizer to exercise persistence, repair attempts, and notifications

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest` *(fails: missing optional dependencies such as pydantic and peewee in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da607390ac832c85bee353290e42c4