### PR TITLE
Optimize local topic search index

### DIFF
--- a/app/adapters/external/firecrawl_parser.py
+++ b/app/adapters/external/firecrawl_parser.py
@@ -5,6 +5,7 @@ import json
 import logging
 import time
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from typing import Any
 
 import httpx
@@ -65,6 +66,30 @@ class FirecrawlResult(BaseModel):
     correlation_id: str | None = Field(
         default=None, description="Firecrawl correlation identifier (cid)."
     )
+
+
+@dataclass(slots=True)
+class FirecrawlSearchItem:
+    """Normalized representation of a Firecrawl `/v1/search` result item."""
+
+    title: str
+    url: str
+    snippet: str | None = None
+    source: str | None = None
+    published_at: str | None = None
+
+
+@dataclass(slots=True)
+class FirecrawlSearchResult:
+    """Result container for Firecrawl search queries."""
+
+    status: str
+    http_status: int | None = None
+    results: list[FirecrawlSearchItem] = field(default_factory=list)
+    total_results: int | None = None
+    latency_ms: int | None = None
+    error_text: str | None = None
+    correlation_id: str | None = None
 
 
 class FirecrawlClient:
@@ -162,6 +187,299 @@ class FirecrawlClient:
 
     async def aclose(self) -> None:
         await self._client.aclose()
+
+    async def search(
+        self,
+        query: str,
+        *,
+        limit: int = 5,
+        request_id: int | None = None,
+    ) -> FirecrawlSearchResult:
+        """Call Firecrawl's search endpoint and normalize the response."""
+
+        trimmed_query = str(query or "").strip()
+        if not trimmed_query:
+            raise ValueError("Search query is required")
+        if len(trimmed_query) > 500:
+            raise ValueError("Search query too long")
+
+        if not isinstance(limit, int):
+            raise ValueError("Search limit must be an integer")
+        if limit <= 0 or limit > 10:
+            raise ValueError("Search limit must be between 1 and 10")
+
+        if request_id is not None and (not isinstance(request_id, int) or request_id <= 0):
+            raise ValueError("Invalid request_id")
+
+        headers = {"Authorization": f"Bearer {self._api_key}"}
+        body = {"query": trimmed_query, "numResults": limit, "page": 1}
+
+        if self._audit:
+            try:
+                self._audit(
+                    "INFO",
+                    "firecrawl_search_request",
+                    {"query": trimmed_query, "limit": limit, "request_id": request_id},
+                )
+            except Exception:
+                pass
+
+        self._logger.debug(
+            "firecrawl_search_request",
+            extra={"query": trimmed_query, "limit": limit, "request_id": request_id},
+        )
+
+        started = time.perf_counter()
+        try:
+            resp = await self._client.post(
+                "https://api.firecrawl.dev/v1/search", headers=headers, json=body
+            )
+        except httpx.HTTPError as exc:
+            latency = int((time.perf_counter() - started) * 1000)
+            error_text = str(exc)
+            self._logger.error(
+                "firecrawl_search_http_error",
+                extra={"error": error_text, "query": trimmed_query},
+            )
+            if self._audit:
+                try:
+                    self._audit(
+                        "ERROR",
+                        "firecrawl_search_http_error",
+                        {"error": error_text, "query": trimmed_query},
+                    )
+                except Exception:
+                    pass
+            return FirecrawlSearchResult(
+                status="error",
+                results=[],
+                latency_ms=latency,
+                error_text=error_text,
+                http_status=None,
+            )
+
+        latency = int((time.perf_counter() - started) * 1000)
+        try:
+            data = resp.json()
+        except json.JSONDecodeError as exc:
+            error_text = f"invalid_json: {exc}"
+            self._logger.error(
+                "firecrawl_search_invalid_json",
+                extra={"error": error_text, "status": resp.status_code},
+            )
+            if self._audit:
+                try:
+                    self._audit(
+                        "ERROR",
+                        "firecrawl_search_invalid_json",
+                        {"status": resp.status_code, "error": error_text},
+                    )
+                except Exception:
+                    pass
+            return FirecrawlSearchResult(
+                status="error",
+                results=[],
+                latency_ms=latency,
+                error_text=error_text,
+                http_status=resp.status_code,
+            )
+
+        correlation_id = None
+        if isinstance(data, dict):
+            correlation_id = data.get("cid") or data.get("correlation_id")
+
+        total_results = self._extract_total_results(data)
+        raw_error = self._extract_error_message(data)
+        raw_items = self._extract_result_items(data)
+
+        items: list[FirecrawlSearchItem] = []
+        seen_urls: set[str] = set()
+        for raw in raw_items:
+            normalized = self._normalize_search_item(raw)
+            if normalized is None:
+                continue
+            if normalized.url in seen_urls:
+                continue
+            seen_urls.add(normalized.url)
+            items.append(normalized)
+            if len(items) >= limit:
+                break
+
+        status = "success"
+        final_error: str | None = None
+
+        if resp.status_code >= 400 or raw_error:
+            status = "error"
+            final_error = raw_error or f"HTTP {resp.status_code}"
+
+        if self._audit:
+            try:
+                self._audit(
+                    "INFO" if status == "success" else "ERROR",
+                    "firecrawl_search_response",
+                    {
+                        "status": status,
+                        "http_status": resp.status_code,
+                        "result_count": len(items),
+                        "query": trimmed_query,
+                    },
+                )
+            except Exception:
+                pass
+
+        self._logger.debug(
+            "firecrawl_search_response",
+            extra={
+                "status": status,
+                "http_status": resp.status_code,
+                "results": len(items),
+                "latency_ms": latency,
+            },
+        )
+
+        return FirecrawlSearchResult(
+            status=status,
+            http_status=resp.status_code,
+            results=items,
+            total_results=total_results,
+            latency_ms=latency,
+            error_text=final_error,
+            correlation_id=correlation_id,
+        )
+
+    @classmethod
+    def _extract_total_results(cls, payload: Any) -> int | None:
+        """Attempt to extract a total results count from the payload."""
+
+        queue: list[Any] = [payload]
+        seen: set[int] = set()
+        while queue:
+            current = queue.pop(0)
+            if id(current) in seen:
+                continue
+            seen.add(id(current))
+
+            if isinstance(current, dict):
+                for key in ("totalResults", "total_results", "numResults", "total"):
+                    value = current.get(key)
+                    if isinstance(value, int) and value >= 0:
+                        return value
+                nested = current.get("data")
+                if nested is not None:
+                    queue.append(nested)
+            elif isinstance(current, list):
+                queue.extend(current)
+        return None
+
+    @classmethod
+    def _extract_error_message(cls, payload: Any) -> str | None:
+        """Extract an error message from Firecrawl payloads if present."""
+
+        if isinstance(payload, dict):
+            for key in ("error", "message"):
+                value = payload.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+            nested = payload.get("data")
+            if nested is not None:
+                nested_error = cls._extract_error_message(nested)
+                if nested_error:
+                    return nested_error
+        elif isinstance(payload, list):
+            for item in payload:
+                nested_error = cls._extract_error_message(item)
+                if nested_error:
+                    return nested_error
+        return None
+
+    @classmethod
+    def _extract_result_items(cls, payload: Any) -> list[dict[str, Any]]:
+        """Locate the list of search result dictionaries within the payload."""
+
+        queue: list[Any] = [payload]
+        seen: set[int] = set()
+        while queue:
+            current = queue.pop(0)
+            if id(current) in seen:
+                continue
+            seen.add(id(current))
+
+            if isinstance(current, list):
+                dict_items = [item for item in current if isinstance(item, dict)]
+                url_items = [item for item in dict_items if cls._has_url_field(item)]
+                if url_items:
+                    return url_items
+                queue.extend(current)
+            elif isinstance(current, dict):
+                if cls._has_url_field(current):
+                    return [current]
+                for key in ("results", "items", "data", "matches"):
+                    if key in current:
+                        queue.append(current[key])
+        return []
+
+    @staticmethod
+    def _has_url_field(item: dict[str, Any]) -> bool:
+        url_value = item.get("url") or item.get("link") or item.get("sourceUrl")
+        if isinstance(url_value, str) and url_value.strip():
+            return True
+        return False
+
+    @classmethod
+    def _normalize_search_item(cls, raw: dict[str, Any]) -> FirecrawlSearchItem | None:
+        """Normalize a raw search item dictionary into ``FirecrawlSearchItem``."""
+
+        url = cls._normalize_text(
+            raw.get("url") or raw.get("link") or raw.get("sourceUrl") or raw.get("permalink")
+        )
+        if not url:
+            return None
+
+        title = (
+            cls._normalize_text(raw.get("title") or raw.get("name") or raw.get("headline")) or url
+        )
+
+        snippet_source = (
+            raw.get("snippet") or raw.get("description") or raw.get("summary") or raw.get("content")
+        )
+        snippet = cls._normalize_text(snippet_source)
+        if snippet:
+            snippet = " ".join(snippet.split())
+
+        source_value: Any = raw.get("source") or raw.get("site") or raw.get("publisher")
+        if isinstance(source_value, dict):
+            source_value = source_value.get("name") or source_value.get("title")
+        elif isinstance(source_value, list):
+            parts = [cls._normalize_text(part) for part in source_value]
+            source_value = ", ".join(part for part in parts if part)
+        source = cls._normalize_text(source_value)
+
+        published_raw = (
+            raw.get("published_at")
+            or raw.get("publishedAt")
+            or raw.get("published")
+            or raw.get("date")
+        )
+        if isinstance(published_raw, dict):
+            published_raw = published_raw.get("iso") or published_raw.get("value")
+        published = cls._normalize_text(published_raw)
+
+        return FirecrawlSearchItem(
+            title=title,
+            url=url,
+            snippet=snippet,
+            source=source,
+            published_at=published,
+        )
+
+    @staticmethod
+    def _normalize_text(value: Any) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, int | float):
+            value = str(value)
+        text = str(value).strip()
+        return text or None
 
     async def scrape_markdown(
         self, url: str, *, mobile: bool = True, request_id: int | None = None

--- a/app/adapters/telegram/command_processor.py
+++ b/app/adapters/telegram/command_processor.py
@@ -15,6 +15,7 @@ from app.config import AppConfig
 from app.core.logging_utils import generate_correlation_id
 from app.core.url_utils import extract_all_urls
 from app.db.user_interactions import async_safe_update_user_interaction
+from app.services.topic_search import LocalTopicSearchService, TopicSearchService
 
 if TYPE_CHECKING:
     from app.adapters.content.url_processor import URLProcessor
@@ -36,6 +37,8 @@ class CommandProcessor:
         url_processor: URLProcessor,
         audit_func: Callable[[str, str, dict], None],
         url_handler: URLHandler | None = None,
+        topic_searcher: TopicSearchService | None = None,
+        local_searcher: LocalTopicSearchService | None = None,
     ) -> None:
         self.cfg = cfg
         self.response_formatter = response_formatter
@@ -43,6 +46,8 @@ class CommandProcessor:
         self.url_processor = url_processor
         self.url_handler: URLHandler | None = url_handler
         self._audit = audit_func
+        self.topic_searcher = topic_searcher
+        self.local_searcher = local_searcher
 
     @staticmethod
     def _maybe_load_json(payload: Any) -> Any:
@@ -284,6 +289,195 @@ class CommandProcessor:
                 interaction_id=interaction_id,
                 response_sent=True,
                 response_type="dbverify",
+                start_time=start_time,
+                logger_=logger,
+            )
+
+    async def handle_find_online_command(
+        self,
+        message: Any,
+        text: str,
+        uid: int,
+        correlation_id: str,
+        interaction_id: int,
+        start_time: float,
+        *,
+        command: str,
+    ) -> None:
+        """Handle Firecrawl-backed search commands."""
+
+        await self._handle_topic_search(
+            message,
+            text,
+            uid,
+            correlation_id,
+            interaction_id,
+            start_time,
+            command=command,
+            searcher=self.topic_searcher,
+            unavailable_message="⚠️ Online article search is currently unavailable.",
+            usage_example="❌ Usage: `{cmd} <topic>`\n\nExample: `{cmd} Android System Design`",
+            invalid_message="❌ Topic must contain visible characters. Try `{cmd} space exploration`.",
+            error_message="⚠️ Unable to search online articles right now. Please try again later.",
+            empty_message="No recent online articles found for **{topic}**.",
+            response_prefix="topic_search_online",
+            log_event="command_find_online",
+            formatter_source="online",
+        )
+
+    async def handle_find_local_command(
+        self,
+        message: Any,
+        text: str,
+        uid: int,
+        correlation_id: str,
+        interaction_id: int,
+        start_time: float,
+        *,
+        command: str,
+    ) -> None:
+        """Handle database-only topic search commands."""
+
+        await self._handle_topic_search(
+            message,
+            text,
+            uid,
+            correlation_id,
+            interaction_id,
+            start_time,
+            command=command,
+            searcher=self.local_searcher,
+            unavailable_message="⚠️ Library search is currently unavailable.",
+            usage_example="❌ Usage: `{cmd} <topic>`\n\nExample: `{cmd} Android System Design`",
+            invalid_message="❌ Topic must contain visible characters. Try `{cmd} space exploration`.",
+            error_message="⚠️ Unable to search saved articles right now. Please try again later.",
+            empty_message="No saved summaries matched **{topic}**.",
+            response_prefix="topic_search_local",
+            log_event="command_find_local",
+            formatter_source="library",
+        )
+
+    async def _handle_topic_search(
+        self,
+        message: Any,
+        text: str,
+        uid: int,
+        correlation_id: str,
+        interaction_id: int,
+        start_time: float,
+        *,
+        command: str,
+        searcher: TopicSearchService | LocalTopicSearchService | None,
+        unavailable_message: str,
+        usage_example: str,
+        invalid_message: str,
+        error_message: str,
+        empty_message: str,
+        response_prefix: str,
+        log_event: str,
+        formatter_source: str,
+    ) -> None:
+        chat_id = getattr(getattr(message, "chat", None), "id", None)
+        logger.info(
+            log_event,
+            extra={
+                "uid": uid,
+                "chat_id": chat_id,
+                "cid": correlation_id,
+                "text": text[:100],
+            },
+        )
+        try:
+            self._audit(
+                "INFO",
+                log_event,
+                {"uid": uid, "chat_id": chat_id, "cid": correlation_id, "text": text[:100]},
+            )
+        except Exception:
+            pass
+
+        if not searcher:
+            await self.response_formatter.safe_reply(message, unavailable_message)
+            if interaction_id:
+                await async_safe_update_user_interaction(
+                    self.db,
+                    interaction_id=interaction_id,
+                    response_sent=True,
+                    response_type=f"{response_prefix}_disabled",
+                    start_time=start_time,
+                    logger_=logger,
+                )
+            return
+
+        parts = text.split(maxsplit=1)
+        topic = parts[1].strip() if len(parts) > 1 else ""
+        if not topic:
+            usage = usage_example.format(cmd=command)
+            await self.response_formatter.safe_reply(message, usage)
+            if interaction_id:
+                await async_safe_update_user_interaction(
+                    self.db,
+                    interaction_id=interaction_id,
+                    response_sent=True,
+                    response_type=f"{response_prefix}_usage",
+                    start_time=start_time,
+                    logger_=logger,
+                )
+            return
+
+        try:
+            results = await searcher.find_articles(topic, correlation_id=correlation_id)
+        except ValueError:
+            invalid = invalid_message.format(cmd=command)
+            await self.response_formatter.safe_reply(message, invalid)
+            if interaction_id:
+                await async_safe_update_user_interaction(
+                    self.db,
+                    interaction_id=interaction_id,
+                    response_sent=True,
+                    response_type=f"{response_prefix}_invalid",
+                    start_time=start_time,
+                    logger_=logger,
+                )
+            return
+        except Exception as exc:  # noqa: BLE001 - defensive catch
+            logger.exception(f"{log_event}_failed", extra={"cid": correlation_id})
+            await self.response_formatter.safe_reply(message, error_message)
+            if interaction_id:
+                await async_safe_update_user_interaction(
+                    self.db,
+                    interaction_id=interaction_id,
+                    response_sent=True,
+                    response_type=f"{response_prefix}_error",
+                    error_occurred=True,
+                    error_message=str(exc)[:500],
+                    start_time=start_time,
+                    logger_=logger,
+                )
+            return
+
+        if not results:
+            await self.response_formatter.safe_reply(message, empty_message.format(topic=topic))
+            if interaction_id:
+                await async_safe_update_user_interaction(
+                    self.db,
+                    interaction_id=interaction_id,
+                    response_sent=True,
+                    response_type=f"{response_prefix}_empty",
+                    start_time=start_time,
+                    logger_=logger,
+                )
+            return
+
+        await self.response_formatter.send_topic_search_results(
+            message, topic=topic, articles=results, source=formatter_source
+        )
+        if interaction_id:
+            await async_safe_update_user_interaction(
+                self.db,
+                interaction_id=interaction_id,
+                response_sent=True,
+                response_type=f"{response_prefix}_results",
                 start_time=start_time,
                 logger_=logger,
             )

--- a/app/adapters/telegram/message_handler.py
+++ b/app/adapters/telegram/message_handler.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from app.adapters.content.url_processor import URLProcessor
     from app.adapters.external.response_formatter import ResponseFormatter
     from app.adapters.telegram.forward_processor import ForwardProcessor
+    from app.services.topic_search import LocalTopicSearchService, TopicSearchService
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +31,8 @@ class MessageHandler:
         response_formatter: ResponseFormatter,
         url_processor: URLProcessor,
         forward_processor: ForwardProcessor,
+        topic_searcher: TopicSearchService | None = None,
+        local_searcher: LocalTopicSearchService | None = None,
     ) -> None:
         self.cfg = cfg
         self.db = db
@@ -55,6 +58,8 @@ class MessageHandler:
             url_processor=url_processor,
             audit_func=self._audit,
             url_handler=self.url_handler,
+            topic_searcher=topic_searcher,
+            local_searcher=local_searcher,
         )
 
         self.message_router = MessageRouter(

--- a/app/adapters/telegram/message_router.py
+++ b/app/adapters/telegram/message_router.py
@@ -214,6 +214,32 @@ class MessageRouter:
             )
             return
 
+        for local_command in ("/finddb", "/findlocal"):
+            if text.startswith(local_command):
+                await self.command_processor.handle_find_local_command(
+                    message,
+                    text,
+                    uid,
+                    correlation_id,
+                    interaction_id,
+                    start_time,
+                    command=local_command,
+                )
+                return
+
+        for online_command in ("/findweb", "/findonline", "/find"):
+            if text.startswith(online_command):
+                await self.command_processor.handle_find_online_command(
+                    message,
+                    text,
+                    uid,
+                    correlation_id,
+                    interaction_id,
+                    start_time,
+                    command=online_command,
+                )
+                return
+
         if text.startswith("/summarize_all"):
             await self.command_processor.handle_summarize_all_command(
                 message, text, uid, correlation_id, interaction_id, start_time

--- a/app/adapters/telegram/telegram_bot.py
+++ b/app/adapters/telegram/telegram_bot.py
@@ -23,6 +23,7 @@ from app.adapters.telegram.telegram_client import TelegramClient
 from app.config import AppConfig
 from app.core.logging_utils import generate_correlation_id, setup_json_logging
 from app.db.database import Database
+from app.services.topic_search import LocalTopicSearchService, TopicSearchService
 
 logger = logging.getLogger(__name__)
 
@@ -125,12 +126,25 @@ class TelegramBot:
             sem=self._sem,
         )
 
+        self.topic_searcher = TopicSearchService(
+            firecrawl=self._firecrawl,
+            max_results=self.cfg.runtime.topic_search_max_results,
+            audit_func=self._audit,
+        )
+        self.local_searcher = LocalTopicSearchService(
+            db=self.db,
+            max_results=self.cfg.runtime.topic_search_max_results,
+            audit_func=self._audit,
+        )
+
         self.message_handler = MessageHandler(
             cfg=self.cfg,
             db=self.db,
             response_formatter=self.response_formatter,
             url_processor=self.url_processor,
             forward_processor=self.forward_processor,
+            topic_searcher=self.topic_searcher,
+            local_searcher=self.local_searcher,
         )
 
         # Route URL handling via the bot instance so legacy tests overriding

--- a/app/db/database.py
+++ b/app/db/database.py
@@ -1208,9 +1208,7 @@ class Database:
                 return
             try:
                 summary_count = Summary.select().where(Summary.json_payload.is_null(False)).count()
-                cursor = self._database.execute_sql(f"SELECT COUNT(*) FROM {table_name}")
-                row = cursor.fetchone()
-                index_count = int(row[0]) if row else 0
+                index_count = TopicSearchIndex.select().count()
             except peewee.DatabaseError as exc:  # pragma: no cover - defensive path
                 self._logger.warning("topic_search_index_count_failed", extra={"error": str(exc)})
                 summary_count = -1

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -6,7 +6,7 @@ import datetime as _dt
 from typing import Any
 
 import peewee
-from playhouse.sqlite_ext import JSONField
+from playhouse.sqlite_ext import FTS5Model, JSONField, SearchField
 
 # A proxy that will be initialised with the concrete database instance at runtime.
 database_proxy: peewee.Database = peewee.DatabaseProxy()
@@ -151,6 +151,24 @@ class Summary(BaseModel):
         table_name = "summaries"
 
 
+class TopicSearchIndex(FTS5Model):
+    """FTS-backed search index for locally stored summaries."""
+
+    request_id = SearchField()
+    url = SearchField()
+    title = SearchField()
+    snippet = SearchField()
+    source = SearchField()
+    published_at = SearchField()
+    body = SearchField()
+    tags = SearchField()
+
+    class Meta:
+        table_name = "topic_search_index"
+        database = database_proxy
+        options = {"content": "", "tokenize": "unicode61 remove_diacritics 2"}
+
+
 class UserInteraction(BaseModel):
     user_id = peewee.BigIntegerField()
     chat_id = peewee.BigIntegerField(null=True)
@@ -200,6 +218,7 @@ ALL_MODELS: tuple[type[BaseModel], ...] = (
     CrawlResult,
     LLMCall,
     Summary,
+    TopicSearchIndex,
     UserInteraction,
     AuditLog,
 )

--- a/app/services/topic_search.py
+++ b/app/services/topic_search.py
@@ -1,0 +1,386 @@
+"""Service helpers for topic-based article discovery."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from app.adapters.external.firecrawl_parser import FirecrawlClient, FirecrawlSearchItem
+from app.db.database import Database
+from app.db.models import Request, Summary
+from app.services.topic_search_utils import (
+    build_snippet,
+    clean_snippet,
+    compose_search_body,
+    ensure_mapping,
+    normalize_text,
+    tokenize,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class TopicArticle:
+    """Lightweight representation of a discovered article."""
+
+    title: str
+    url: str
+    snippet: str | None = None
+    source: str | None = None
+    published_at: str | None = None
+
+
+class TopicSearchService:
+    """Facade that wraps Firecrawl search for topic-based article discovery."""
+
+    def __init__(
+        self,
+        firecrawl: FirecrawlClient,
+        *,
+        max_results: int,
+        audit_func: Callable[[str, str, dict[str, Any]], None] | None = None,
+    ) -> None:
+        if max_results <= 0:
+            raise ValueError("max_results must be positive")
+        if max_results > 10:
+            raise ValueError("max_results must be 10 or fewer")
+
+        self._firecrawl = firecrawl
+        self._max_results = max_results
+        self._audit = audit_func
+
+    async def find_articles(
+        self, topic: str, *, correlation_id: str | None = None
+    ) -> list[TopicArticle]:
+        """Return a curated list of articles for the provided topic."""
+
+        query = (topic or "").strip()
+        if not query:
+            raise ValueError("Topic query must not be empty")
+
+        try:
+            result = await self._firecrawl.search(query, limit=self._max_results)
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "topic_search_request_failed", extra={"cid": correlation_id, "topic": query}
+            )
+            raise
+
+        if result.status != "success":
+            message = result.error_text or "Search request failed"
+            if self._audit:
+                try:
+                    self._audit(
+                        "ERROR",
+                        "topic_search_failed",
+                        {
+                            "topic": query,
+                            "cid": correlation_id,
+                            "status": result.status,
+                            "http_status": result.http_status,
+                            "error": message,
+                        },
+                    )
+                except Exception:  # pragma: no cover - defensive audit
+                    pass
+            raise RuntimeError(message)
+
+        articles = self._normalize_articles(result.results)
+
+        if self._audit:
+            try:
+                self._audit(
+                    "INFO",
+                    "topic_search_completed",
+                    {
+                        "topic": query,
+                        "cid": correlation_id,
+                        "results": len(articles),
+                        "total_results": result.total_results,
+                    },
+                )
+            except Exception:  # pragma: no cover - defensive audit
+                pass
+
+        return articles
+
+    def _normalize_articles(self, raw_items: Iterable[FirecrawlSearchItem]) -> list[TopicArticle]:
+        """Normalize Firecrawl search items into ``TopicArticle`` objects."""
+
+        articles: list[TopicArticle] = []
+        seen_urls: set[str] = set()
+        for item in raw_items:
+            if not item.url or item.url in seen_urls:
+                continue
+            seen_urls.add(item.url)
+
+            title = item.title.strip() if item.title else item.url
+            snippet = clean_snippet(item.snippet)
+            source = item.source.strip() if item.source else None
+            published = item.published_at.strip() if item.published_at else None
+
+            articles.append(
+                TopicArticle(
+                    title=title,
+                    url=item.url,
+                    snippet=snippet,
+                    source=source,
+                    published_at=published,
+                )
+            )
+
+            if len(articles) >= self._max_results:
+                break
+
+        return articles
+
+
+class LocalTopicSearchService:
+    """Search service that queries stored summaries in the local database."""
+
+    def __init__(
+        self,
+        db: Database,
+        *,
+        max_results: int,
+        audit_func: Callable[[str, str, dict[str, Any]], None] | None = None,
+        max_scan: int | None = None,
+    ) -> None:
+        if max_results <= 0:
+            raise ValueError("max_results must be positive")
+        if max_results > 25:
+            raise ValueError("max_results must be 25 or fewer")
+
+        self._db = db
+        self._max_results = max_results
+        self._max_scan = (
+            max(200, max_results * 40) if max_scan is None else max(max_scan, max_results)
+        )
+        self._audit = audit_func
+
+    async def find_articles(
+        self, topic: str, *, correlation_id: str | None = None
+    ) -> list[TopicArticle]:
+        """Return locally stored articles that match the requested topic."""
+
+        query = (topic or "").strip()
+        if not query:
+            raise ValueError("Topic query must not be empty")
+
+        try:
+            articles = await asyncio.to_thread(self._search_sync, query)
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "local_topic_search_failed", extra={"cid": correlation_id, "topic": query}
+            )
+            raise
+
+        if self._audit:
+            try:
+                self._audit(
+                    "INFO",
+                    "local_topic_search_completed",
+                    {
+                        "topic": query,
+                        "cid": correlation_id,
+                        "results": len(articles),
+                    },
+                )
+            except Exception:  # pragma: no cover - defensive audit
+                pass
+
+        return articles
+
+    def _search_sync(self, query: str) -> list[TopicArticle]:
+        terms = tokenize(query)
+        normalized_query = query.casefold()
+
+        articles = self._search_via_index(query, terms)
+        if len(articles) >= self._max_results:
+            return articles[: self._max_results]
+
+        remaining = self._max_results - len(articles)
+        if remaining <= 0:
+            return articles
+
+        seen_urls = {article.url for article in articles}
+        fallback_articles = self._scan_summaries(
+            terms=terms,
+            normalized_query=normalized_query,
+            seen_urls=seen_urls,
+            limit=remaining,
+        )
+        articles.extend(fallback_articles)
+        return articles[: self._max_results]
+
+    def _search_via_index(self, query: str, terms: Sequence[str]) -> list[TopicArticle]:
+        if not terms:
+            sanitized = self._sanitize_fts_term(query.casefold())
+            if not sanitized:
+                return []
+            fts_query = f'"{sanitized}"*'
+        else:
+            sanitized_terms = [self._sanitize_fts_term(term) for term in terms]
+            sanitized_terms = [term for term in sanitized_terms if term]
+            if not sanitized_terms:
+                return []
+            phrase = self._sanitize_fts_term(" ".join(terms))
+            wildcard_terms = [f'"{term}"*' for term in sanitized_terms]
+            components = [" AND ".join(wildcard_terms)]
+            if phrase:
+                components.append(f'"{phrase}"')
+            fts_query = " OR ".join(component for component in components if component)
+
+        candidate_limit = max(self._max_results * 5, 25)
+        sql = (
+            "SELECT rowid, url, title, snippet, source, published_at "
+            "FROM topic_search_index "
+            "WHERE topic_search_index MATCH ? "
+            "ORDER BY bm25(topic_search_index) ASC "
+            "LIMIT ?"
+        )
+
+        articles: list[TopicArticle] = []
+        seen_urls: set[str] = set()
+
+        try:
+            with self._db._database.connection_context():
+                cursor = self._db._database.execute_sql(sql, (fts_query, candidate_limit))
+                rows = list(cursor)
+        except Exception as exc:  # noqa: BLE001 - fall back to scan logic
+            logger.warning("local_topic_search_index_query_failed", extra={"error": str(exc)})
+            return []
+
+        for row in rows:
+            url = normalize_text(self._row_value(row, 1, "url"))
+            if not url or url in seen_urls:
+                continue
+
+            title = normalize_text(self._row_value(row, 2, "title")) or url
+            snippet = clean_snippet(self._row_value(row, 3, "snippet"))
+            source = normalize_text(self._row_value(row, 4, "source"))
+            published = normalize_text(self._row_value(row, 5, "published_at"))
+
+            articles.append(
+                TopicArticle(
+                    title=title,
+                    url=url,
+                    snippet=snippet,
+                    source=source,
+                    published_at=published,
+                )
+            )
+            seen_urls.add(url)
+            if len(articles) >= self._max_results:
+                break
+
+        return articles
+
+    def _scan_summaries(
+        self,
+        *,
+        terms: Sequence[str],
+        normalized_query: str,
+        seen_urls: set[str],
+        limit: int,
+    ) -> list[TopicArticle]:
+        if limit <= 0:
+            return []
+
+        articles: list[TopicArticle] = []
+
+        with self._db._database.connection_context():
+            query = (
+                Summary.select(Summary, Request)
+                .join(Request)
+                .where(Summary.json_payload.is_null(False))
+                .order_by(Summary.created_at.desc())
+            )
+            if self._max_scan:
+                query = query.limit(self._max_scan)
+
+            for row in query:
+                payload = ensure_mapping(row.json_payload)
+                metadata = ensure_mapping(payload.get("metadata"))
+
+                url = (
+                    normalize_text(metadata.get("canonical_url"))
+                    or normalize_text(metadata.get("url"))
+                    or normalize_text(getattr(row.request, "normalized_url", None))
+                    or normalize_text(getattr(row.request, "input_url", None))
+                )
+                if not url or url in seen_urls:
+                    continue
+
+                title = (
+                    normalize_text(metadata.get("title"))
+                    or normalize_text(payload.get("title"))
+                    or url
+                )
+
+                haystack, _ = compose_search_body(
+                    title=title,
+                    payload=payload,
+                    metadata=metadata,
+                    content_text=getattr(row.request, "content_text", None),
+                )
+
+                if not self._matches(terms, normalized_query, haystack):
+                    continue
+
+                snippet = build_snippet(payload)
+                source = normalize_text(metadata.get("domain") or metadata.get("source"))
+                published = normalize_text(
+                    metadata.get("published_at")
+                    or metadata.get("published")
+                    or metadata.get("last_updated")
+                )
+
+                articles.append(
+                    TopicArticle(
+                        title=title,
+                        url=url,
+                        snippet=snippet,
+                        source=source,
+                        published_at=published,
+                    )
+                )
+
+                seen_urls.add(url)
+                if len(articles) >= limit:
+                    break
+
+        return articles
+
+    @staticmethod
+    def _matches(terms: Sequence[str], normalized_query: str, haystack: str) -> bool:
+        if not haystack:
+            return False
+        if not terms:
+            return normalized_query in haystack
+        return all(term in haystack for term in terms)
+
+    @staticmethod
+    def _sanitize_fts_term(term: str) -> str:
+        sanitized = re.sub(r"[^\w-]+", " ", term)
+        sanitized = re.sub(r"\s+", " ", sanitized).strip()
+        return sanitized
+
+    @staticmethod
+    def _row_value(row: Any, index: int, key: str) -> Any:
+        if isinstance(row, dict):
+            return row.get(key)
+        if hasattr(row, "keys"):
+            try:
+                return row[key]
+            except Exception:  # pragma: no cover - defensive fallback
+                pass
+        try:
+            return row[index]
+        except Exception:  # pragma: no cover - defensive fallback
+            return None

--- a/app/services/topic_search_utils.py
+++ b/app/services/topic_search_utils.py
@@ -1,0 +1,179 @@
+"""Utility helpers shared by topic search services and index builders."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(slots=True)
+class TopicSearchDocument:
+    """Precomputed representation of a summary suitable for indexing."""
+
+    request_id: int
+    url: str | None
+    title: str | None
+    snippet: str | None
+    source: str | None
+    published_at: str | None
+    body: str
+    tags_text: str | None
+
+
+def ensure_mapping(value: Any) -> dict[str, Any]:
+    """Return a mapping for JSON-like data, gracefully handling text payloads."""
+
+    if isinstance(value, Mapping):
+        return dict(value)
+    if isinstance(value, str):
+        try:
+            loaded = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(loaded, Mapping):
+            return dict(loaded)
+    return {}
+
+
+def normalize_text(value: Any) -> str | None:
+    """Normalize primitive values into trimmed text suitable for display."""
+
+    if value is None:
+        return None
+    if isinstance(value, int | float):
+        value = str(value)
+    text = str(value).strip()
+    return text or None
+
+
+def clean_snippet(snippet: str | None, *, limit: int = 300) -> str | None:
+    """Normalize snippet text into a compact preview."""
+
+    if not snippet:
+        return None
+    compact = " ".join(snippet.split())
+    if not compact:
+        return None
+    if len(compact) > limit:
+        compact = compact[: limit - 3].rstrip() + "..."
+    return compact
+
+
+def build_snippet(payload: Mapping[str, Any]) -> str | None:
+    """Return the best available short summary snippet from a payload."""
+
+    for key in ("summary_250", "summary_1000", "tldr"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return clean_snippet(value)
+    return None
+
+
+def tokenize(query: str) -> list[str]:
+    """Split a query into normalized search terms."""
+
+    return [piece for piece in re.findall(r"[\w-]+", query.casefold()) if piece]
+
+
+def _append_metadata_values(parts: list[str], value: Any) -> None:
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        parts.extend(str(item) for item in value if item)
+    elif isinstance(value, str):
+        parts.append(value)
+
+
+def compose_search_body(
+    *,
+    title: str | None,
+    payload: Mapping[str, Any],
+    metadata: Mapping[str, Any],
+    content_text: str | None,
+) -> tuple[str, str | None]:
+    """Compose a lower-cased document body and tag text for indexing/search."""
+
+    parts: list[str] = []
+    if title:
+        parts.append(title)
+
+    for key in ("summary_250", "summary_1000", "tldr"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            parts.append(value)
+
+    tag_values: list[str] = []
+    topic_tags = payload.get("topic_tags")
+    if isinstance(topic_tags, Sequence) and not isinstance(topic_tags, str | bytes | bytearray):
+        for tag in topic_tags:
+            if not tag:
+                continue
+            tag_text = normalize_text(tag)
+            if not tag_text:
+                continue
+            tag_values.append(tag_text)
+            parts.append(tag_text)
+
+    metadata_values: Iterable[Any] = (
+        metadata.get("description"),
+        metadata.get("keywords"),
+        metadata.get("section"),
+    )
+    for value in metadata_values:
+        _append_metadata_values(parts, value)
+
+    if isinstance(content_text, str):
+        parts.append(content_text)
+
+    normalized = " ".join(str(part) for part in parts if part)
+    tags_text = " ".join(tag_values) if tag_values else None
+    return normalized.casefold(), tags_text
+
+
+def build_topic_search_document(
+    *,
+    request_id: int,
+    payload: Mapping[str, Any],
+    request_data: Mapping[str, Any],
+) -> TopicSearchDocument | None:
+    """Create a document payload for indexing from a stored summary."""
+
+    metadata = ensure_mapping(payload.get("metadata"))
+
+    url = (
+        normalize_text(metadata.get("canonical_url"))
+        or normalize_text(metadata.get("url"))
+        or normalize_text(request_data.get("normalized_url"))
+        or normalize_text(request_data.get("input_url"))
+    )
+    if not url:
+        return None
+
+    title = normalize_text(metadata.get("title")) or normalize_text(payload.get("title")) or url
+
+    body, tags_text = compose_search_body(
+        title=title,
+        payload=payload,
+        metadata=metadata,
+        content_text=normalize_text(request_data.get("content_text")),
+    )
+    if not body.strip():
+        return None
+
+    snippet = build_snippet(payload)
+    source = normalize_text(metadata.get("domain") or metadata.get("source"))
+    published = normalize_text(
+        metadata.get("published_at") or metadata.get("published") or metadata.get("last_updated")
+    )
+
+    return TopicSearchDocument(
+        request_id=request_id,
+        url=url,
+        title=title,
+        snippet=snippet,
+        source=source,
+        published_at=published,
+        body=body,
+        tags_text=tags_text,
+    )

--- a/tests/test_topic_search_service.py
+++ b/tests/test_topic_search_service.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from app.adapters.external.firecrawl_parser import (
+    FirecrawlClient,
+    FirecrawlSearchItem,
+    FirecrawlSearchResult,
+)
+from app.db.database import Database
+from app.services.topic_search import LocalTopicSearchService, TopicSearchService
+
+
+class DummyFirecrawl:
+    def __init__(self, result: FirecrawlSearchResult) -> None:
+        self.result = result
+        self.calls: list[tuple[str, int]] = []
+
+    async def search(self, query: str, *, limit: int = 5) -> FirecrawlSearchResult:
+        self.calls.append((query, limit))
+        return self.result
+
+
+@pytest.mark.asyncio
+async def test_find_articles_normalizes_and_limits() -> None:
+    long_snippet = "This is a long snippet " * 30
+    result = FirecrawlSearchResult(
+        status="success",
+        results=[
+            FirecrawlSearchItem(
+                title="Android Architecture Guide",
+                url="https://example.com/android-architecture",
+                snippet=long_snippet,
+                source="Example News",
+                published_at="2024-02-15",
+            ),
+            FirecrawlSearchItem(
+                title="Scaling Android Services",
+                url="https://example.com/android-services",
+                snippet="Insights on scaling Android services across regions.",
+                source=None,
+                published_at=None,
+            ),
+            FirecrawlSearchItem(
+                title="Duplicate Entry",
+                url="https://example.com/android-architecture",
+                snippet="Duplicate should be ignored.",
+                source="Example News",
+                published_at="2024-02-16",
+            ),
+        ],
+        total_results=3,
+    )
+
+    dummy = DummyFirecrawl(result)
+    service = TopicSearchService(cast(FirecrawlClient, dummy), max_results=2)
+
+    articles = await service.find_articles("Android System Design", correlation_id="cid-42")
+
+    assert dummy.calls == [("Android System Design", 2)]
+    assert len(articles) == 2
+    assert articles[0].url == "https://example.com/android-architecture"
+    assert articles[0].snippet is not None and articles[0].snippet.endswith("...")
+    assert articles[1].url == "https://example.com/android-services"
+
+
+@pytest.mark.asyncio
+async def test_find_articles_raises_on_error_status() -> None:
+    result = FirecrawlSearchResult(
+        status="error",
+        results=[],
+        error_text="quota exceeded",
+        http_status=429,
+    )
+
+    dummy = DummyFirecrawl(result)
+    service = TopicSearchService(cast(FirecrawlClient, dummy), max_results=3)
+
+    with pytest.raises(RuntimeError, match="quota exceeded"):
+        await service.find_articles("Android System Design")
+
+
+@pytest.mark.asyncio
+async def test_local_search_returns_recent_matches(tmp_path) -> None:
+    db_path = tmp_path / "app.db"
+    database = Database(str(db_path))
+    database.migrate()
+
+    request_id = database.create_request(
+        type_="url",
+        status="completed",
+        correlation_id="cid-1",
+        chat_id=1,
+        user_id=1,
+        input_url="https://example.com/android",
+        content_text="Android systems excel at modular design principles.",
+    )
+    database.insert_summary(
+        request_id=request_id,
+        lang="en",
+        json_payload={
+            "summary_250": "Android system design focuses on scalable services.",
+            "topic_tags": ["Android", "Architecture"],
+            "metadata": {
+                "title": "Android System Design 101",
+                "canonical_url": "https://example.com/android",
+                "domain": "example.com",
+                "published_at": "2024-01-01",
+            },
+        },
+    )
+
+    other_request = database.create_request(
+        type_="url",
+        status="completed",
+        correlation_id="cid-2",
+        chat_id=1,
+        user_id=1,
+        input_url="https://example.com/cooking",
+        content_text="All about pasta.",
+    )
+    database.insert_summary(
+        request_id=other_request,
+        lang="en",
+        json_payload={
+            "summary_250": "A deep dive into homemade pasta techniques.",
+            "metadata": {
+                "title": "Making Pasta",
+                "canonical_url": "https://example.com/cooking",
+                "domain": "example.com",
+            },
+        },
+    )
+
+    service = LocalTopicSearchService(db=database, max_results=2)
+
+    results = await service.find_articles("Android System Design")
+
+    assert len(results) == 1
+    article = results[0]
+    assert article.url == "https://example.com/android"
+    assert article.title.startswith("Android System Design")
+    assert article.source == "example.com"
+    assert article.snippet is not None and "android" in article.snippet.lower()
+
+
+@pytest.mark.asyncio
+async def test_local_search_handles_empty_results(tmp_path) -> None:
+    database = Database(str(tmp_path / "app.db"))
+    database.migrate()
+
+    service = LocalTopicSearchService(db=database, max_results=3)
+    results = await service.find_articles("Nonexistent Topic")
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_local_search_rejects_blank_queries(tmp_path) -> None:
+    database = Database(str(tmp_path / "app.db"))
+    database.migrate()
+    service = LocalTopicSearchService(db=database, max_results=2)
+
+    with pytest.raises(ValueError):
+        await service.find_articles("   ")
+
+
+@pytest.mark.asyncio
+async def test_local_search_index_finds_older_match(tmp_path) -> None:
+    database = Database(str(tmp_path / "app.db"))
+    database.migrate()
+
+    matching_request = database.create_request(
+        type_="url",
+        status="completed",
+        correlation_id="cid-3",
+        chat_id=1,
+        user_id=1,
+        input_url="https://example.com/android-old",
+        content_text="Legacy overview of Android modular design patterns.",
+    )
+    database.insert_summary(
+        request_id=matching_request,
+        lang="en",
+        json_payload={
+            "summary_250": "Android modular design enables reliable scaling.",
+            "metadata": {
+                "title": "Designing Android Systems",
+                "canonical_url": "https://example.com/android-old",
+                "domain": "example.com",
+                "published_at": "2023-10-01",
+            },
+        },
+    )
+
+    # Insert a newer, non-matching summary so fallback scans would skip the older entry.
+    newer_request = database.create_request(
+        type_="url",
+        status="completed",
+        correlation_id="cid-4",
+        chat_id=1,
+        user_id=1,
+        input_url="https://example.com/cooking-souffle",
+        content_text="All about baking souffles.",
+    )
+    database.insert_summary(
+        request_id=newer_request,
+        lang="en",
+        json_payload={
+            "summary_250": "Souffles require gentle heat and timing.",
+            "metadata": {
+                "title": "Baking the Perfect Souffle",
+                "canonical_url": "https://example.com/cooking-souffle",
+                "domain": "example.com",
+            },
+        },
+    )
+
+    service = LocalTopicSearchService(db=database, max_results=1, max_scan=1)
+
+    results = await service.find_articles("Android modular design")
+
+    assert results
+    assert results[0].url == "https://example.com/android-old"
+
+
+def test_database_populates_topic_search_index(tmp_path) -> None:
+    database = Database(str(tmp_path / "app.db"))
+    database.migrate()
+
+    request_id = database.create_request(
+        type_="url",
+        status="completed",
+        correlation_id="cid-5",
+        chat_id=1,
+        user_id=1,
+        input_url="https://example.com/ai",
+        content_text="Artificial intelligence fundamentals.",
+    )
+    database.insert_summary(
+        request_id=request_id,
+        lang="en",
+        json_payload={
+            "summary_250": "AI systems rely on data and iterative training.",
+            "metadata": {
+                "title": "AI Fundamentals",
+                "canonical_url": "https://example.com/ai",
+                "domain": "example.com",
+            },
+        },
+    )
+
+    with database._database.connection_context():
+        cursor = database._database.execute_sql(
+            "SELECT url, title, body FROM topic_search_index LIMIT 1"
+        )
+        row = cursor.fetchone()
+
+    assert row is not None
+    assert "android" not in row[2]
+    assert row[0] == "https://example.com/ai"
+    assert "AI Fundamentals" in row[1]


### PR DESCRIPTION
## Summary
- add reusable topic search utilities for normalization, snippet handling, and index document construction
- introduce an FTS-backed TopicSearchIndex plus database refresh/rebuild helpers so stored summaries stay searchable
- update the local topic search service to query the index first with a fallback scan and extend coverage with index-specific tests

## Testing
- ruff check . --fix
- ruff format .
- mypy .
- pytest tests/test_commands.py tests/test_topic_search_service.py *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68de205ec5fc832cb192027110f4a331