### PR TITLE
Add fallback summary generation for missing primary fields

### DIFF
--- a/tests/test_summary_contract.py
+++ b/tests/test_summary_contract.py
@@ -59,6 +59,23 @@ class TestSummaryContract(unittest.TestCase):
         self.assertEqual(out["entities"]["organizations"], ["OpenAI", "Anthropic"])
         self.assertEqual(out["entities"]["locations"], ["San Francisco", "New York"])
 
+    def test_fallback_summary_from_supporting_fields(self):
+        payload = {
+            "key_ideas": [
+                "Key idea one highlights the main vulnerability.",
+                "Key idea two explains the mitigation steps.",
+            ],
+            "highlights": ["Highlight content adds additional context."],
+            "insights": {"topic_overview": "Overall, the article explores safety bypasses."},
+        }
+
+        out = validate_and_shape_summary(payload)
+
+        self.assertTrue(out["summary_250"].strip())
+        self.assertTrue(out["summary_1000"].strip())
+        self.assertTrue(out["tldr"].strip())
+        self.assertIn("Key idea one", out["summary_1000"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add a helper that builds fallback summaries from supporting fields when the primary summary strings are empty
- populate summary_250, summary_1000, and tldr from the fallback text so salvage succeeds after structured output errors
- cover the new fallback behaviour with a summary contract unit test

## Testing
- ruff check . --fix
- ruff format .
- mypy .
- pytest tests/test_summary_contract.py

------
https://chatgpt.com/codex/tasks/task_e_68de380c9620832c99d58089c9ee5d2e