### PR TITLE
Handle mentions in unread command parsing

### DIFF
--- a/app/adapters/telegram/command_processor.py
+++ b/app/adapters/telegram/command_processor.py
@@ -707,10 +707,17 @@ class CommandProcessor:
         if not remainder:
             return 5, None
 
+        tokens = remainder.split()
+        if tokens and tokens[0].startswith("@"):
+            tokens = tokens[1:]
+
+        if not tokens:
+            return 5, None
+
         max_limit = 20
         limit = 5
         topic_parts: list[str] = []
-        for raw_token in remainder.split():
+        for raw_token in tokens:
             token = raw_token.strip()
             if not token:
                 continue

--- a/tests/test_read_status.py
+++ b/tests/test_read_status.py
@@ -4,6 +4,7 @@ import unittest
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
+from app.adapters.telegram.command_processor import CommandProcessor
 from app.adapters.telegram.telegram_bot import TelegramBot
 from app.config import AppConfig, FirecrawlConfig, OpenRouterConfig, RuntimeConfig, TelegramConfig
 from app.db.database import Database
@@ -98,6 +99,23 @@ def make_bot(tmp_path: str) -> ReadStatusBot:
     setattr(tbmod, "Client", object)
     setattr(tbmod, "filters", None)
     return ReadStatusBot(cfg=cfg, db=Database(tmp_path))
+
+
+class TestParseUnreadArguments(unittest.TestCase):
+    def test_parse_unread_with_mention_only(self) -> None:
+        limit, topic = CommandProcessor._parse_unread_arguments("/unread@bot")
+        self.assertEqual(limit, 5)
+        self.assertIsNone(topic)
+
+    def test_parse_unread_with_mention_and_limit(self) -> None:
+        limit, topic = CommandProcessor._parse_unread_arguments("/unread@bot 3")
+        self.assertEqual(limit, 3)
+        self.assertIsNone(topic)
+
+    def test_parse_unread_with_mention_and_topic(self) -> None:
+        limit, topic = CommandProcessor._parse_unread_arguments("/unread@bot gardening")
+        self.assertEqual(limit, 5)
+        self.assertEqual(topic, "gardening")
 
 
 class TestReadStatusDatabase(unittest.TestCase):


### PR DESCRIPTION
## Summary
- strip a leading bot mention from /unread command arguments before parsing limits and topics
- add unit tests covering /unread@bot variants to ensure mentions do not affect limit or topic parsing

## Testing
- ruff check . --fix
- ruff format .
- mypy .
- pytest tests/test_read_status.py -k mention

------
https://chatgpt.com/codex/tasks/task_e_68e0d927e478832c9d47052893fced7c