### PR TITLE
Handle unread metadata safely

### DIFF
--- a/app/adapters/telegram/command_processor.py
+++ b/app/adapters/telegram/command_processor.py
@@ -17,6 +17,7 @@ from app.core.logging_utils import generate_correlation_id
 from app.core.url_utils import extract_all_urls
 from app.db.user_interactions import async_safe_update_user_interaction
 from app.services.topic_search import LocalTopicSearchService, TopicSearchService
+from app.services.topic_search_utils import ensure_mapping
 
 if TYPE_CHECKING:
     from app.adapters.content.url_processor import URLProcessor
@@ -796,11 +797,8 @@ class CommandProcessor:
                 # Extract title from metadata if available
                 payload = self._maybe_load_json(summary.get("json_payload"))
                 if isinstance(payload, Mapping):
-                    title = (
-                        payload.get("metadata", {}).get("title")
-                        or payload.get("title")
-                        or input_url
-                    )
+                    metadata = ensure_mapping(payload.get("metadata"))
+                    title = metadata.get("title") or payload.get("title") or input_url
                 else:
                     title = input_url
 

--- a/tests/test_read_status.py
+++ b/tests/test_read_status.py
@@ -513,7 +513,29 @@ class TestReadStatusCommands(unittest.IsolatedAsyncioTestCase):
             bot = make_bot(os.path.join(tmp, "app.db"))
 
             # Create some unread articles
-            for i, url in enumerate(["https://example1.com", "https://example2.com"]):
+            details = [
+                (
+                    "https://example1.com",
+                    {"title": "Article 1", "metadata": {"title": "Article 1"}},
+                ),
+                (
+                    "https://example2.com",
+                    {"title": "Article 2", "metadata": {"title": "Article 2"}},
+                ),
+                (
+                    "https://example3.com",
+                    {"title": "Article 3", "metadata": None},
+                ),
+                (
+                    "https://example4.com",
+                    {
+                        "title": "Article 4",
+                        "metadata": '{"title": "Article 4"}',
+                    },
+                ),
+            ]
+
+            for i, (url, payload) in enumerate(details, start=1):
                 rid = bot.db.create_request(
                     type_="url",
                     status="ok",
@@ -526,10 +548,7 @@ class TestReadStatusCommands(unittest.IsolatedAsyncioTestCase):
                 bot.db.insert_summary(
                     request_id=rid,
                     lang="en",
-                    json_payload={
-                        "title": f"Article {i + 1}",
-                        "metadata": {"title": f"Article {i + 1}"},
-                    },
+                    json_payload=payload,
                     is_read=False,
                 )
 
@@ -543,6 +562,8 @@ class TestReadStatusCommands(unittest.IsolatedAsyncioTestCase):
             self.assertIn("Article 1", reply)
             self.assertIn("Article 2", reply)
             self.assertIn("Request ID", reply)
+            self.assertIn("Article 3", reply)
+            self.assertIn("Article 4", reply)
 
     async def test_unread_command_with_topic_and_limit(self):
         """/unread accepts topic filters and limits results."""


### PR DESCRIPTION
## Summary
- coerce unread summary metadata through ensure_mapping before accessing title fields
- extend the /unread command test fixture to cover None and string metadata inputs

## Testing
- ruff check . --fix
- ruff format .
- mypy .
- pytest tests/test_read_status.py -k unread_command -q *(fails: missing optional dependency `pydantic` in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e7311964832cb0170fdf6aec9219