### PR TITLE
Preserve numeric unread topics when parsing

### DIFF
--- a/tests/test_read_status.py
+++ b/tests/test_read_status.py
@@ -117,6 +117,16 @@ class TestParseUnreadArguments(unittest.TestCase):
         self.assertEqual(limit, 5)
         self.assertEqual(topic, "gardening")
 
+    def test_parse_unread_with_numeric_topic_only(self) -> None:
+        limit, topic = CommandProcessor._parse_unread_arguments("/unread 2024")
+        self.assertEqual(limit, 5)
+        self.assertEqual(topic, "2024")
+
+    def test_parse_unread_with_numeric_topic_and_limit(self) -> None:
+        limit, topic = CommandProcessor._parse_unread_arguments("/unread 2024 limit=3")
+        self.assertEqual(limit, 3)
+        self.assertEqual(topic, "2024")
+
 
 class TestReadStatusDatabase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- refine unread argument parsing to keep numeric tokens as topics unless they are real limits
- add regression tests covering numeric unread topics with and without explicit limits

## Testing
- ruff check . --fix
- ruff format .
- mypy .
- pytest tests/test_read_status.py -k TestParseUnreadArguments

------
https://chatgpt.com/codex/tasks/task_e_68e0e7310c60832c9a3b85061217dc1c