### PR TITLE
Refine unread command parsing and tests

### DIFF
--- a/app/db/database.py
+++ b/app/db/database.py
@@ -1512,7 +1512,7 @@ class Database:
 
         try:
             self._database.execute_sql(
-                "INSERT INTO topic_search_index(topic_search_index, rowid) VALUES ('delete', ?)",
+                "DELETE FROM topic_search_index WHERE rowid = ?",
                 (rowid,),
             )
         except peewee.DatabaseError as exc:
@@ -1522,13 +1522,6 @@ class Database:
                 return
 
             self._log_topic_search_delete_fallback(rowid, message)
-            try:
-                self._database.execute_sql(
-                    "DELETE FROM topic_search_index WHERE rowid = ?",
-                    (rowid,),
-                )
-            except peewee.DatabaseError as fallback_exc:  # pragma: no cover - defensive
-                self._handle_topic_search_index_error(fallback_exc, rowid)
 
     def _log_topic_search_delete_fallback(self, rowid: int, message: str) -> None:
         """Log degraded delete path, but only warn once to avoid noise."""

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -166,7 +166,7 @@ class TopicSearchIndex(FTS5Model):
     class Meta:
         table_name = "topic_search_index"
         database = database_proxy
-        options = {"content": "", "tokenize": "unicode61 remove_diacritics 2"}
+        options = {"tokenize": "unicode61 remove_diacritics 2"}
 
 
 class UserInteraction(BaseModel):

--- a/tests/test_read_status.py
+++ b/tests/test_read_status.py
@@ -127,6 +127,26 @@ class TestParseUnreadArguments(unittest.TestCase):
         self.assertEqual(limit, 3)
         self.assertEqual(topic, "2024")
 
+    def test_parse_unread_with_topic_and_trailing_limit(self) -> None:
+        limit, topic = CommandProcessor._parse_unread_arguments("/unread ai 2")
+        self.assertEqual(limit, 2)
+        self.assertEqual(topic, "ai")
+
+    def test_parse_unread_trailing_limit_above_max_is_topic(self) -> None:
+        limit, topic = CommandProcessor._parse_unread_arguments("/unread ai 99")
+        self.assertEqual(limit, 5)
+        self.assertEqual(topic, "ai 99")
+
+    def test_parse_unread_numeric_only_without_mention_is_topic(self) -> None:
+        limit, topic = CommandProcessor._parse_unread_arguments("/unread 3")
+        self.assertEqual(limit, 5)
+        self.assertEqual(topic, "3")
+
+    def test_parse_unread_numeric_only_with_mention_is_limit(self) -> None:
+        limit, topic = CommandProcessor._parse_unread_arguments("/unread@bot 4")
+        self.assertEqual(limit, 4)
+        self.assertIsNone(topic)
+
 
 class TestReadStatusDatabase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- adjust the unread command argument parser so mentions and trailing numeric limits are handled while preserving numeric topics and ignoring oversized limits
- update the topic search index to retain stored content and simplify row deletions to avoid corruption errors
- filter pytest async hook arguments to match coroutine signatures, allowing tmp_path-based tests to execute
- add targeted unread argument parsing tests that cover mention heuristics and trailing numeric limits

## Testing
- pytest
- ruff check . --fix
- ruff format .
- mypy .

------
https://chatgpt.com/codex/tasks/task_e_68e12611bdec832c8d908ed37033380a