### PR TITLE
Improve Telegram URL handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,7 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks tests as integration tests",
     "unit: marks tests as unit tests",
+    "asyncio: marks tests that rely on pytest-asyncio",
 ]
 asyncio_default_fixture_loop_scope = "function"
 

--- a/tests/test_url_handler.py
+++ b/tests/test_url_handler.py
@@ -1,0 +1,91 @@
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.adapters.telegram.url_handler import URLHandler
+
+if TYPE_CHECKING:
+    from app.adapters.content.url_processor import URLProcessor
+    from app.adapters.external.response_formatter import ResponseFormatter
+    from app.db.database import Database
+else:  # pragma: no cover - runtime fallback for typing-only imports
+    URLProcessor = ResponseFormatter = Database = Any  # type: ignore[assignment]
+
+
+@pytest.mark.asyncio
+async def test_handle_awaited_url_rejects_invalid_links() -> None:
+    safe_reply_mock = AsyncMock()
+    response_formatter = cast(
+        "ResponseFormatter",
+        SimpleNamespace(
+            MAX_BATCH_URLS=5,
+            safe_reply=safe_reply_mock,
+            _validate_url=MagicMock(return_value=(False, "bad")),
+        ),
+    )
+    handle_url_flow_mock = AsyncMock()
+    url_processor = cast(
+        "URLProcessor",
+        SimpleNamespace(handle_url_flow=handle_url_flow_mock),
+    )
+    handler = URLHandler(
+        db=cast("Database", SimpleNamespace()),
+        response_formatter=response_formatter,
+        url_processor=url_processor,
+    )
+
+    message = SimpleNamespace(chat=None)
+
+    await handler.handle_awaited_url(
+        message,
+        "https://localhost/resource",
+        uid=99,
+        correlation_id="cid",
+        interaction_id=0,
+        start_time=0.0,
+    )
+
+    assert safe_reply_mock.await_count == 1
+    assert handle_url_flow_mock.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_handle_awaited_url_filters_invalid_before_processing() -> None:
+    safe_reply_mock = AsyncMock()
+    response_formatter = cast(
+        "ResponseFormatter",
+        SimpleNamespace(
+            MAX_BATCH_URLS=5,
+            safe_reply=safe_reply_mock,
+            _validate_url=MagicMock(side_effect=[(True, ""), (False, "bad")]),
+        ),
+    )
+    handle_url_flow_mock = AsyncMock()
+    url_processor = cast(
+        "URLProcessor",
+        SimpleNamespace(handle_url_flow=handle_url_flow_mock),
+    )
+    handler = URLHandler(
+        db=cast("Database", SimpleNamespace()),
+        response_formatter=response_formatter,
+        url_processor=url_processor,
+    )
+    multi_link_mock = AsyncMock()
+    cast("Any", handler)._request_multi_link_confirmation = multi_link_mock
+
+    message = SimpleNamespace(chat=None)
+
+    await handler.handle_awaited_url(
+        message,
+        "https://valid.example/path https://localhost/resource",
+        uid=42,
+        correlation_id="cid",
+        interaction_id=0,
+        start_time=0.0,
+    )
+
+    assert handle_url_flow_mock.await_count == 1
+    assert multi_link_mock.await_count == 0
+    assert safe_reply_mock.await_count == 0


### PR DESCRIPTION
## Summary
- apply a shared `_apply_url_security_checks` helper so both awaited and direct Telegram links are validated and batch-limited
- register the `asyncio` pytest marker so async unit tests can run under `--strict-markers`
- add regression tests that cover awaited URL validation edge cases

## Testing
- `PYENV_VERSION=3.11.12 pytest tests/test_url_handler.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a075cbb94832ca4a3b06fc8ec77fe)