### PR TITLE
Scope unread summaries by user context

### DIFF
--- a/app/adapters/telegram/command_processor.py
+++ b/app/adapters/telegram/command_processor.py
@@ -874,7 +874,12 @@ class CommandProcessor:
                     )
             else:
                 # Fallback to direct database access if container not available
-                unread_summaries = self.db.get_unread_summaries(limit=limit, topic=topic)
+                unread_summaries = self.db.get_unread_summaries(
+                    user_id=uid,
+                    chat_id=chat_id,
+                    limit=limit,
+                    topic=topic,
+                )
 
             if not unread_summaries:
                 if topic:

--- a/app/infrastructure/persistence/sqlite/repositories/summary_repository.py
+++ b/app/infrastructure/persistence/sqlite/repositories/summary_repository.py
@@ -52,7 +52,11 @@ class SqliteSummaryRepositoryAdapter:
         return await self._db.async_get_summary_by_id(summary_id)
 
     async def async_get_unread_summaries(
-        self, uid: int, cid: int, limit: int = 10, topic: str | None = None
+        self,
+        uid: int | None,
+        cid: int | None,
+        limit: int = 10,
+        topic: str | None = None,
     ) -> list[dict[str, Any]]:
         """Get unread summaries for a user.
 

--- a/app/protocols.py
+++ b/app/protocols.py
@@ -101,7 +101,11 @@ class SummaryRepository(Protocol):
         ...
 
     async def async_get_unread_summaries(
-        self, uid: int, cid: int, limit: int = 10
+        self,
+        uid: int | None,
+        cid: int | None,
+        limit: int = 10,
+        topic: str | None = None,
     ) -> list[dict[str, Any]]:
         """Get unread summaries for a user.
 

--- a/app/repositories.py
+++ b/app/repositories.py
@@ -111,10 +111,14 @@ class SummaryRepositoryImpl:
         return await self._db.async_get_summary_by_request(request_id)
 
     async def async_get_unread_summaries(
-        self, uid: int, cid: int, limit: int = 10
+        self,
+        uid: int | None,
+        cid: int | None,
+        limit: int = 10,
+        topic: str | None = None,
     ) -> list[dict[str, Any]]:
         """Get unread summaries for a user."""
-        return await self._db.async_get_unread_summaries(uid, cid, limit)
+        return await self._db.async_get_unread_summaries(uid, cid, limit, topic)
 
     async def async_get_unread_summary_by_request_id(
         self, request_id: int

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,12 +51,23 @@ class MockSummaryRepository:
         return self.summaries.get(request_id)
 
     async def async_get_unread_summaries(
-        self, uid: int, cid: int, limit: int = 10
+        self,
+        uid: int | None,
+        cid: int | None,
+        limit: int = 10,
+        topic: str | None = None,
     ) -> list[dict[str, Any]]:
         """Mock get unread summaries."""
         unread = [
             summary for summary in self.summaries.values() if not summary.get("is_read", False)
         ]
+        if topic:
+            topic_lower = topic.casefold()
+            unread = [
+                summary
+                for summary in unread
+                if topic_lower in str(summary["json_payload"]).casefold()
+            ]
         return unread[:limit]
 
     async def async_mark_summary_as_read(self, summary_id: int) -> None:


### PR DESCRIPTION
## Summary
- scope the unread summaries query in the database to optional user and chat filters and propagate the new signature across the adapters and protocol
- ensure the Telegram command handler fallback path supplies the caller context so that users can only see their own saved summaries
- update the mocks and unit tests to cover the new filtering behavior

## Testing
- `PYENV_VERSION=3.11.12 pytest tests/test_read_status.py::TestReadStatusDatabase::test_get_unread_summaries_filters_by_user_and_chat -q`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a1d2a1f88832c8d593d260c39601e)