### PR TITLE
Stabilize CI dependencies and async tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ permissions:
   pull-requests: write
   checks: write
 
+env:
+  UV_EXTRA_INDEX_URL: "https://download.pytorch.org/whl/cpu"
+  UV_INDEX_STRATEGY: "unsafe-best-match"
+
 jobs:
   prepare-environment:
     name: Prepare dependencies
@@ -151,7 +155,7 @@ jobs:
             -p pytest_cov \
             -p xdist \
             -p pytest_rerunfailures \
-            -p pytest_asyncio \
+            -p pytest_asyncio.plugin \
             tests/ \
             -m "not slow and not integration" \
             --cov=app \

--- a/.github/workflows/regenerate-lockfiles.yml
+++ b/.github/workflows/regenerate-lockfiles.yml
@@ -15,6 +15,10 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  UV_EXTRA_INDEX_URL: "https://download.pytorch.org/whl/cpu"
+  UV_INDEX_STRATEGY: "unsafe-best-match"
+
 jobs:
   regen-lockfiles:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-locks.yml
+++ b/.github/workflows/update-locks.yml
@@ -18,6 +18,10 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  UV_EXTRA_INDEX_URL: "https://download.pytorch.org/whl/cpu"
+  UV_INDEX_STRATEGY: "unsafe-best-match"
+
 jobs:
   update-locks:
     runs-on: ubuntu-latest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -250,8 +250,10 @@ sentence-transformers==5.1.2
     # via bite-size-reader (pyproject.toml)
 setuptools==80.9.0
     # via
+    #   pymorphy3
     #   spacy
     #   thinc
+    #   torch
 six==1.17.0
     # via python-dateutil
 smart-open==7.5.0
@@ -284,7 +286,7 @@ tld==0.13.1
     # via courlan
 tokenizers==0.22.1
     # via transformers
-torch==2.9.1
+torch==2.9.1+cpu
     # via sentence-transformers
 tqdm==4.67.1
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -213,8 +213,10 @@ sentence-transformers==5.1.2
     # via bite-size-reader (pyproject.toml)
 setuptools==80.9.0
     # via
+    #   pymorphy3
     #   spacy
     #   thinc
+    #   torch
 six==1.17.0
     # via python-dateutil
 smart-open==7.5.0
@@ -247,7 +249,7 @@ tld==0.13.1
     # via courlan
 tokenizers==0.22.1
     # via transformers
-torch==2.9.1
+torch==2.9.1+cpu
     # via sentence-transformers
 tqdm==4.67.1
     # via


### PR DESCRIPTION
## Summary
- ensure CI and lockfile workflows compile and install dependencies from CPU-friendly PyTorch wheels
- pin torch to the CPU build in both runtime and dev requirements to avoid GPU dependency downloads
- explicitly load the pytest-asyncio plugin in CI test runs when plugin auto-loading is disabled

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p xdist -p pytest_asyncio.plugin tests/ -m "not slow and not integration" --maxfail=1 --strict-markers --disable-warnings -q -n auto


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ad73ce890832caaabb5b242a19a04)