### PR TITLE
Add Chroma-based semantic search service and endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Environment
 - `PREFERRED_LANG=auto` (auto|en|ru)
 - `DEBUG_PAYLOADS=0` — when `1`, logs request/response payload previews for Firecrawl/OpenRouter (with Authorization redacted)
  - `MAX_CONCURRENT_CALLS=4` — caps simultaneous Firecrawl/OpenRouter calls
+- Semantic search uses the Chroma vector backend; ensure `CHROMA_HOST`, `CHROMA_AUTH_TOKEN` (if required), and related settings point to a reachable Chroma deployment.
 
 Repository layout
 - `app/core` — URL normalization, JSON contract, logging, language helpers

--- a/app/services/chroma_vector_search_service.py
+++ b/app/services/chroma_vector_search_service.py
@@ -1,0 +1,202 @@
+"""Semantic search service backed by Chroma vector store."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Iterable  # noqa: TC003
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.core.lang import detect_language
+from app.infrastructure.vector.chroma_store import ChromaVectorStore  # noqa: TC001
+from app.services.embedding_service import EmbeddingService  # noqa: TC001
+
+logger = logging.getLogger(__name__)
+
+
+class ChromaVectorSearchResult(BaseModel):
+    """Normalized result returned by Chroma vector queries."""
+
+    model_config = ConfigDict(frozen=True)
+
+    request_id: int
+    summary_id: int
+    similarity_score: float = Field(ge=0.0, le=1.0)
+    url: str | None = None
+    title: str | None = None
+    snippet: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    language: str | None = None
+
+
+class ChromaVectorSearchResults(BaseModel):
+    """Collection of Chroma search results with pagination hints."""
+
+    model_config = ConfigDict(frozen=True)
+
+    results: list[ChromaVectorSearchResult]
+    has_more: bool = False
+
+
+class ChromaVectorSearchService:
+    """Run semantic search queries against Chroma using request metadata."""
+
+    def __init__(
+        self,
+        *,
+        vector_store: ChromaVectorStore,
+        embedding_service: EmbeddingService,
+        default_top_k: int = 25,
+    ) -> None:
+        if default_top_k <= 0:
+            msg = "default_top_k must be positive"
+            raise ValueError(msg)
+
+        self._vector_store = vector_store
+        self._embedding_service = embedding_service
+        self._default_top_k = default_top_k
+
+    async def search(
+        self,
+        query: str,
+        *,
+        language: str | None = None,
+        tags: Iterable[str] | None = None,
+        user_scope: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> ChromaVectorSearchResults:
+        """Search Chroma for summaries similar to the query text."""
+
+        if not query or not query.strip():
+            logger.warning("chroma_search_empty_query")
+            return ChromaVectorSearchResults(results=[], has_more=False)
+
+        requested_limit = limit or self._default_top_k
+        fetch_limit = requested_limit + offset + 1  # +1 to detect has_more
+
+        detected_language = language or detect_language(query)
+
+        try:
+            query_embedding = await self._embedding_service.generate_embedding(
+                query.strip(), language=detected_language
+            )
+        except Exception:
+            logger.exception(
+                "chroma_search_embedding_failed",
+                extra={"language": detected_language},
+            )
+            return ChromaVectorSearchResults(results=[], has_more=False)
+
+        filters = self._build_filters(language=detected_language, tags=tags, user_scope=user_scope)
+
+        try:
+            raw = await asyncio.to_thread(
+                self._vector_store.query,
+                query_embedding,
+                filters,
+                fetch_limit,
+            )
+        except Exception:
+            logger.exception("chroma_search_query_failed")
+            return ChromaVectorSearchResults(results=[], has_more=False)
+
+        metadatas = raw.get("metadatas") or []
+        distances = raw.get("distances") or []
+
+        if not metadatas or not isinstance(metadatas, list):
+            return ChromaVectorSearchResults(results=[], has_more=False)
+
+        first_batch = metadatas[0] or []
+        distance_batch = distances[0] if distances else []
+
+        results: list[ChromaVectorSearchResult] = []
+
+        for idx, metadata in enumerate(first_batch):
+            if not isinstance(metadata, dict):
+                continue
+
+            request_id = self._safe_int(metadata.get("request_id"))
+            summary_id = self._safe_int(metadata.get("summary_id"))
+
+            if request_id is None or summary_id is None:
+                continue
+
+            similarity_score = self._compute_similarity(distance_batch, idx)
+            snippet = metadata.get("text")
+            if snippet and len(str(snippet)) > 300:
+                snippet = str(snippet)[:297] + "..."
+
+            results.append(
+                ChromaVectorSearchResult(
+                    request_id=request_id,
+                    summary_id=summary_id,
+                    similarity_score=similarity_score,
+                    url=metadata.get("url"),
+                    title=metadata.get("title"),
+                    snippet=snippet,
+                    tags=self._normalize_tags(metadata.get("tags")),
+                    language=metadata.get("language"),
+                )
+            )
+
+        has_more = len(results) > offset + requested_limit
+        return ChromaVectorSearchResults(
+            results=results[offset : offset + requested_limit],
+            has_more=has_more,
+        )
+
+    @staticmethod
+    def _compute_similarity(distances: list[float], idx: int) -> float:
+        distance = 0.0
+        if 0 <= idx < len(distances):
+            try:
+                distance = float(distances[idx])
+            except (TypeError, ValueError):
+                distance = 0.0
+
+        if 0.0 <= distance <= 1.0:
+            return max(0.0, 1.0 - distance)
+        return 1.0 / (1.0 + distance) if distance >= 0 else 0.0
+
+    @staticmethod
+    def _safe_int(value: Any) -> int | None:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _normalize_tags(tags: Any) -> list[str]:
+        if not tags:
+            return []
+        if isinstance(tags, str):
+            return [tags]
+        if isinstance(tags, (list, tuple, set)):
+            clean: list[str] = []
+            for tag in tags:
+                text = str(tag).strip()
+                if text:
+                    clean.append(text)
+            return clean
+        return []
+
+    @staticmethod
+    def _build_filters(
+        *, language: str | None, tags: Iterable[str] | None, user_scope: str | None
+    ) -> dict[str, Any]:
+        filters: dict[str, Any] = {}
+
+        if language:
+            filters["language"] = language
+
+        normalized_tags = [tag for tag in (tags or []) if str(tag).strip()]
+        if normalized_tags:
+            filters["$and"] = [{"tags": {"$contains": tag}} for tag in normalized_tags]
+
+        if user_scope:
+            filters["user_scope"] = user_scope
+
+        return filters


### PR DESCRIPTION
## Summary
- add a Chroma-backed vector search service that generates query embeddings and applies optional metadata filters
- introduce a semantic search API route that mirrors the existing search contract while sourcing results from Chroma
- document that semantic search requires access to the Chroma backend

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693148b013b4832ca79c80638a43e1ad)