### PR TITLE
Add Rust migration audit doc and characterization tests to lock behavior

### DIFF
--- a/docs/audits/rust-migration-audit.md
+++ b/docs/audits/rust-migration-audit.md
@@ -1,0 +1,143 @@
+# Project Audit & Rust Migration Assessment
+
+## Current architecture snapshot
+
+- **Primary product**: Async Telegram bot that summarizes web pages and YouTube videos into strict JSON, with SQLite persistence.
+- **Feature surface** includes Telegram handling, URL extraction/summarization, channel digests, optional Redis caching, optional Chroma vector search, MCP server exposure, and a FastAPI mobile API.
+- **Scale indicator**: 625 Python files (178 test files).
+
+## Code health observations (desloppify)
+
+Latest local scan highlights:
+
+- Strict score: **33.5/100**.
+- Open findings: **1424** (T2: 118, T3: 928, T4: 378).
+- Detector highlights include orphaned modules, broad/silent exception patterns, and test coverage debt.
+
+## Rust migration feasibility
+
+### Why migration is plausible
+
+- The system already has **clean external boundaries**:
+  - gRPC contract (`processing.proto`) for request submission + progress streaming.
+  - HTTP-based integrations (OpenRouter, Firecrawl, Karakeep).
+  - SQLite + Redis + optional Chroma as infrastructure dependencies available in Rust ecosystems.
+- Several domains are CPU/latency sensitive (content parsing, queueing, heavy async orchestration), where Rust could improve memory safety and predictability.
+
+### Why full rewrite is high risk now
+
+- Broad functional scope (bot + API + MCP + optional integrations) creates a large parity matrix.
+- Current quality debt suggests behavior is still being stabilized; translating unstable behavior can freeze accidental complexity into a new language.
+- Python-specific ecosystem usage (spaCy pipeline + many optional packages) means non-trivial replacement/FFI decisions.
+
+## How to reduce critical debt before migration
+
+Treat debt burn-down as a **pre-migration hardening sprint** with explicit gates.
+
+### 1) Triage by risk, not by count
+
+Prioritize findings that most affect production safety and migration ambiguity:
+
+1. Security findings first
+2. Broad/silent exception patterns in production paths
+3. Orphaned/unused modules that blur ownership
+4. High-complexity modules on critical user flows
+5. Coverage gaps for request processing, persistence, and Telegram command routing
+
+### 2) Work in focused clusters
+
+Use cluster-focused loops instead of sweeping edits:
+
+```bash
+desloppify next --cluster auto/smells-broad_except --count 10
+desloppify next --cluster auto/smells-silent_except --count 10
+desloppify next --cluster auto/orphaned --count 10
+```
+
+After each batch:
+
+```bash
+desloppify scan --path .
+desloppify status
+```
+
+### 3) Define quality gates for migration readiness
+
+A practical baseline before the first Rust slice:
+
+- Strict score > 60
+- All security findings resolved or explicitly justified
+- Broad/silent exception clusters reduced to only intentional boundary handlers
+- Top 10 user flows have characterization tests
+- CI green for lint/type/unit/integration suites
+
+## How to lock behavior with characterization tests
+
+Characterization tests capture **current observable behavior** so migration preserves outcomes even when internals change.
+
+### Test selection strategy
+
+Write tests around externally visible contracts only:
+
+- Telegram command inputs → emitted bot responses
+- URL submission → status progression → final summary persistence
+- API/gRPC request payloads → response/error shape
+- Retry/fallback behavior for external provider failures
+- Idempotency and duplicate request handling
+
+### Test design rules
+
+- Use real request/response fixtures from logs or known regressions.
+- Assert outputs, side effects, and error envelopes (not internal call order).
+- Freeze nondeterminism (time/UUID/random/network) with fixtures and fakes.
+- Keep current quirks if clients depend on them; annotate as legacy behavior.
+
+### Concrete test harness pattern
+
+1. **Golden fixture tests**
+   - Input payloads in `tests/fixtures/`.
+   - Expected JSON/text outputs committed as snapshot files.
+2. **Protocol contract tests**
+   - Validate gRPC/OpenAPI schema compatibility and error code mapping.
+3. **Persistence invariants**
+   - Assert SQLite row-level invariants after core flows (request, summary, audit log state).
+4. **Failure-mode tests**
+   - Provider timeout, malformed payload, DB lock contention, retry exhaustion.
+
+### Suggested immediate characterization backlog (first 2 weeks)
+
+1. `/summary <url>` happy path (article)
+2. YouTube transcript path + fallback behavior
+3. `/search` + unread/read state transitions
+4. gRPC `SubmitUrl` stream ordering and terminal state
+5. API auth + sync endpoint response compatibility
+
+## Recommended migration strategy
+
+1. **Stabilize before translating**
+   - Raise strict score materially first (e.g., >60) and reduce key clusters (orphaned/broad-except/silent-except).
+   - Add characterization tests for critical user flows.
+2. **Start with hybrid architecture**
+   - Keep Python orchestration initially.
+   - Move one isolated capability to Rust behind gRPC/HTTP (e.g., URL normalization + content chunking, or DB write queue service).
+3. **Migrate service-by-service, not file-by-file**
+   - Candidate order: stateless utility service → high-throughput worker → API endpoints → Telegram orchestration (last).
+4. **Keep protocol-first contracts**
+   - Expand protobuf/OpenAPI contracts before implementation moves.
+   - Run compatibility tests against both Python and Rust implementations.
+5. **Set explicit rollback criteria**
+   - P95 latency, failure rate, and operational complexity thresholds decide whether each migrated slice remains in Rust.
+
+## Rust crate mapping (if proceeding)
+
+- Async runtime: `tokio`
+- HTTP server/client: `axum` + `reqwest`
+- gRPC: `tonic`
+- DB: `sqlx` (SQLite)
+- Redis: `redis` crate
+- Structured config: `serde` + `config`
+- Tracing/metrics: `tracing`, `metrics`, `opentelemetry`
+
+## Suggested first Rust pilot
+
+Implement a **standalone processing worker** that consumes URL jobs and emits progress updates via gRPC, while Python remains the Telegram/API control plane. This minimizes blast radius, validates team Rust velocity, and preserves current product behavior.

--- a/tests/characterization/test_auth_sync_characterization.py
+++ b/tests/characterization/test_auth_sync_characterization.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Avoid importing optional heavy vector deps while loading API routers package.
+sys.modules.setdefault("chromadb", MagicMock())
+sys.modules.setdefault("chromadb.config", MagicMock())
+sys.modules.setdefault("chromadb.errors", MagicMock())
+
+from app.api.models.auth import TelegramLoginRequest
+from app.api.models.requests import SyncSessionRequest
+from app.api.routers import sync as sync_router
+from app.api.routers.auth import endpoints_telegram
+
+
+@pytest.mark.asyncio
+async def test_characterization_telegram_login_response_shape_is_stable() -> None:
+    login = TelegramLoginRequest(
+        telegram_user_id=12345,
+        auth_hash="deadbeef",
+        auth_date=1700000000,
+        username="characterization",
+        first_name="Char",
+        last_name="Test",
+        photo_url=None,
+        client_id="mobile-ios",
+    )
+
+    with (
+        patch.object(endpoints_telegram, "validate_client_id", return_value=None),
+        patch.object(endpoints_telegram, "verify_telegram_auth", return_value=None),
+        patch.object(
+            endpoints_telegram.SqliteUserRepositoryAdapter,
+            "async_get_or_create_user",
+            AsyncMock(return_value=({"telegram_user_id": 12345, "username": "characterization"}, True)),
+        ),
+        patch.object(endpoints_telegram, "create_access_token", return_value="access-token"),
+        patch.object(endpoints_telegram.logger, "info", return_value=None),
+        patch.object(
+            endpoints_telegram,
+            "create_refresh_token",
+            AsyncMock(return_value=("refresh-token", 1)),
+        ),
+    ):
+        response = await endpoints_telegram.telegram_login(login)
+
+    assert response["success"] is True
+    assert response["data"]["tokens"]["accessToken"] == "access-token"
+    assert response["data"]["tokens"]["refreshToken"] == "refresh-token"
+    assert response["data"]["tokens"]["tokenType"] == "Bearer"
+    assert response["data"]["sessionId"] == 1
+
+
+@pytest.mark.asyncio
+async def test_characterization_sync_session_response_shape_is_stable() -> None:
+    from pydantic import BaseModel, Field
+
+    class FakeSyncSession(BaseModel):
+        session_id: str = Field(serialization_alias="sessionId")
+        server_version: int = Field(serialization_alias="serverVersion")
+        expires_at: str = Field(serialization_alias="expiresAt")
+        default_limit: int = Field(serialization_alias="defaultLimit")
+
+    fake_session = FakeSyncSession(
+        session_id="sync-1",
+        server_version=10,
+        expires_at="2026-01-01T00:00:00Z",
+        default_limit=100,
+    )
+
+    fake_service = type(
+        "Svc",
+        (),
+        {
+            "start_session": AsyncMock(return_value=fake_session),
+        },
+    )()
+
+    with patch.object(sync_router, "_get_sync_service", return_value=fake_service):
+        response = await sync_router.create_sync_session(
+            body=SyncSessionRequest(limit=50),
+            user={"user_id": 7, "client_id": "mobile-ios"},
+        )
+
+    assert response["success"] is True
+    assert response["data"]["sessionId"] == "sync-1"
+    assert response["meta"]["pagination"]["limit"] == 100
+    assert response["meta"]["pagination"]["hasMore"] is True

--- a/tests/characterization/test_immediate_backlog.py
+++ b/tests/characterization/test_immediate_backlog.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.adapters.youtube.youtube_downloader import YouTubeDownloader
+from app.application.use_cases.get_unread_summaries import GetUnreadSummariesQuery, GetUnreadSummariesUseCase
+from app.application.use_cases.mark_summary_as_read import (
+    MarkSummaryAsReadCommand,
+    MarkSummaryAsReadUseCase,
+)
+from app.application.use_cases.mark_summary_as_unread import (
+    MarkSummaryAsUnreadCommand,
+    MarkSummaryAsUnreadUseCase,
+)
+from tests.conftest import make_test_app_config
+from tests.test_commands import BotSpy, FakeMessage
+
+pytest.importorskip("grpc", reason="grpcio not installed")
+
+from app.grpc.client import ProcessingClient
+from app.protos import processing_pb2
+
+
+async def _async_generator(items):
+    for item in items:
+        yield item
+
+
+@pytest.mark.asyncio
+async def test_characterization_summary_command_happy_path_preserved() -> None:
+    """Lock current /summarize command behavior for a single URL."""
+    cfg = make_test_app_config(db_path=":memory:", allowed_user_ids=(1, 42))
+
+    from app.adapters import telegram_bot as tbmod
+
+    tbmod.Client = object
+    tbmod.filters = None
+
+    from unittest.mock import patch
+
+    with patch("app.adapters.openrouter.openrouter_client.OpenRouterClient") as mock_openrouter:
+        mock_openrouter.return_value = AsyncMock()
+        bot = BotSpy(cfg=cfg, db=MagicMock())
+
+    url = "https://example.com/characterization"
+    msg = FakeMessage(f"/summarize {url}")
+
+    await bot._on_message(msg)
+
+    assert url in bot.seen_urls
+    assert any(url in reply for reply in msg._replies)
+
+
+@pytest.mark.asyncio
+async def test_characterization_youtube_uses_vtt_fallback_when_api_transcript_empty(
+    tmp_path,
+) -> None:
+    """Lock fallback behavior: empty API transcript should use downloaded VTT subtitles."""
+    cfg = MagicMock()
+    cfg.youtube.storage_path = str(tmp_path / "videos")
+    cfg.youtube.max_video_size_mb = 500
+    cfg.youtube.max_storage_gb = 100
+    cfg.youtube.preferred_quality = "1080p"
+    cfg.youtube.subtitle_languages = ["en"]
+    cfg.youtube.auto_cleanup_enabled = False
+    cfg.youtube.cleanup_after_days = 30
+
+    rf = MagicMock()
+    rf.sender.send_message_draft = AsyncMock()
+    rf.sender.safe_reply = AsyncMock()
+    rf.notifications.send_youtube_download_notification = AsyncMock()
+    rf.notifications.send_youtube_download_complete_notification = AsyncMock()
+
+    downloader = YouTubeDownloader(cfg=cfg, db=MagicMock(), response_formatter=rf, audit_func=lambda *_a, **_k: None)
+
+    downloader._check_storage_limits = AsyncMock()
+    downloader.request_repo = MagicMock()
+    downloader.video_repo = MagicMock()
+
+    downloader.request_repo.async_get_request_by_dedupe_hash = AsyncMock(return_value=None)
+    downloader.video_repo.async_get_video_download_by_request = AsyncMock(return_value=None)
+    downloader.video_repo.async_create_video_download = AsyncMock(return_value=900)
+    downloader.video_repo.async_update_video_download_status = AsyncMock()
+    downloader.video_repo.async_update_video_download = AsyncMock()
+    downloader.request_repo.async_update_request_status = AsyncMock()
+    downloader.request_repo.async_update_request_lang_detected = AsyncMock()
+    downloader._create_video_request = AsyncMock(return_value=500)
+
+    downloader._extract_transcript_api = AsyncMock(return_value=("", "", False, "api"))
+    downloader._download_video_sync = MagicMock(
+        return_value={
+            "title": "Example video",
+            "channel": "Channel",
+            "channel_id": "ch-1",
+            "duration": 123,
+            "upload_date": "20260101",
+            "view_count": 1000,
+            "like_count": 100,
+            "resolution": "1080p",
+            "file_size": 1024 * 1024,
+            "vcodec": "h264",
+            "acodec": "aac",
+            "format_id": "137+140",
+            "subtitle_file_path": str(tmp_path / "captions.en.vtt"),
+        }
+    )
+    downloader._load_transcript_from_vtt = MagicMock(return_value=("vtt transcript body", "en"))
+
+    req_id, combined_text, transcript_source, detected_lang, _metadata = await downloader.download_and_extract(
+        message=MagicMock(),
+        url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        silent=True,
+    )
+
+    assert req_id == 500
+    assert transcript_source == "vtt"
+    assert detected_lang == "en"
+    assert "vtt transcript body" in combined_text
+    downloader.video_repo.async_update_video_download.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_characterization_unread_read_unread_transition_with_topic_filter() -> None:
+    """Lock unread filtering and read-state transitions around topic-like filtering."""
+    class InMemorySummaryRepo:
+        def __init__(self) -> None:
+            self.rows = {
+                1: {
+                    "id": 1,
+                    "request_id": 10,
+                    "lang": "en",
+                    "json_payload": {"title": "Rust migration notes", "topic_tags": ["rust"], "tldr": "r", "summary_250": "rust", "key_ideas": ["idea"]},
+                    "is_read": False,
+                    "version": 1,
+                },
+                2: {
+                    "id": 2,
+                    "request_id": 11,
+                    "lang": "en",
+                    "json_payload": {"title": "Python release notes", "topic_tags": ["python"], "tldr": "p", "summary_250": "python", "key_ideas": ["idea"]},
+                    "is_read": False,
+                    "version": 1,
+                },
+            }
+
+        async def async_get_unread_summaries(self, uid, cid, limit=10, topic=None):
+            _ = (uid, cid)
+            unread = [v for v in self.rows.values() if not v["is_read"]]
+            if topic:
+                t = topic.casefold()
+                unread = [r for r in unread if t in str(r["json_payload"]).casefold()]
+            return unread[:limit]
+
+        async def async_get_summary_by_id(self, summary_id: int):
+            return self.rows.get(summary_id)
+
+        async def async_mark_summary_as_read(self, summary_id: int):
+            self.rows[summary_id]["is_read"] = True
+
+        async def async_mark_summary_as_unread(self, summary_id: int):
+            self.rows[summary_id]["is_read"] = False
+
+        def to_domain_model(self, db_summary):
+            from datetime import datetime
+
+            from app.domain.models.summary import Summary
+
+            return Summary(
+                id=db_summary["id"],
+                request_id=db_summary["request_id"],
+                content=db_summary["json_payload"],
+                language=db_summary["lang"],
+                version=db_summary["version"],
+                is_read=db_summary["is_read"],
+                created_at=datetime.utcnow(),
+            )
+
+    repo = InMemorySummaryRepo()
+    unread_use_case = GetUnreadSummariesUseCase(repo)
+    mark_read = MarkSummaryAsReadUseCase(repo)
+    mark_unread = MarkSummaryAsUnreadUseCase(repo)
+
+    rust_only = await unread_use_case.execute(GetUnreadSummariesQuery(user_id=1, chat_id=1, topic="rust"))
+    assert [s.id for s in rust_only] == [1]
+
+    await mark_read.execute(MarkSummaryAsReadCommand(summary_id=1, user_id=1))
+    rust_after_read = await unread_use_case.execute(
+        GetUnreadSummariesQuery(user_id=1, chat_id=1, topic="rust")
+    )
+    assert rust_after_read == []
+
+    await mark_unread.execute(MarkSummaryAsUnreadCommand(summary_id=1, user_id=1))
+    rust_after_unread = await unread_use_case.execute(
+        GetUnreadSummariesQuery(user_id=1, chat_id=1, topic="rust")
+    )
+    assert [s.id for s in rust_after_unread] == [1]
+
+
+@pytest.mark.asyncio
+async def test_characterization_grpc_submit_url_stream_order_and_terminal_state() -> None:
+    """Lock stream contract: queued -> processing -> done with terminal summary id."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    updates = [
+        processing_pb2.ProcessingUpdate(
+            request_id=101,
+            status=processing_pb2.ProcessingStatus.ProcessingStatus_PENDING,
+            stage=processing_pb2.ProcessingStage.ProcessingStage_QUEUED,
+            message="queued",
+            progress=0.0,
+        ),
+        processing_pb2.ProcessingUpdate(
+            request_id=101,
+            status=processing_pb2.ProcessingStatus.ProcessingStatus_PROCESSING,
+            stage=processing_pb2.ProcessingStage.ProcessingStage_EXTRACTION,
+            message="extracting",
+            progress=0.3,
+        ),
+        processing_pb2.ProcessingUpdate(
+            request_id=101,
+            status=processing_pb2.ProcessingStatus.ProcessingStatus_COMPLETED,
+            stage=processing_pb2.ProcessingStage.ProcessingStage_DONE,
+            message="done",
+            progress=1.0,
+            summary_id=777,
+        ),
+    ]
+
+    mock_channel = MagicMock()
+    mock_channel.channel_ready = AsyncMock()
+    mock_channel.close = AsyncMock()
+
+    mock_stub = MagicMock()
+    mock_stub.SubmitUrl = MagicMock(return_value=_async_generator(updates))
+
+    with patch("grpc.aio.insecure_channel", return_value=mock_channel), patch(
+        "app.grpc.client.processing_pb2_grpc.ProcessingServiceStub", return_value=mock_stub
+    ):
+        client = ProcessingClient("localhost:50051")
+        await client.connect()
+
+        received = []
+        async for u in client.submit_url("https://example.com/article"):
+            received.append(u)
+
+        assert [u.status for u in received] == ["PENDING", "PROCESSING", "COMPLETED"]
+        assert received[-1].summary_id == 777


### PR DESCRIPTION
### Motivation

- Provide a focused migration assessment and practical plan for incrementally moving parts of the system to Rust while reducing risk.  
- Capture and lock current observable behavior with characterization tests so future rewrites preserve public contracts.  
- Surface and prioritize technical debt and quality gates that must be addressed before starting a Rust pilot.

### Description

- Add `docs/audits/rust-migration-audit.md` containing a migration feasibility assessment, triage and hardening recommendations, test and contract guidance, and a suggested Rust pilot and crate mapping.  
- Add `tests/characterization/test_auth_sync_characterization.py` which contains characterization tests for Telegram login response shape and sync session response shape.  
- Add `tests/characterization/test_immediate_backlog.py` which contains multiple characterization tests for the `/summarize` command, YouTube VTT fallback behavior, unread/read state transitions with topic filtering, and the gRPC `SubmitUrl` stream ordering and terminal state.  
- Use mocks/fakes and `pytest.importorskip` where appropriate to avoid pulling heavy optional dependencies in CI and to freeze nondeterminism in tests.

### Testing

- Ran the new characterization test suite with `pytest -q tests/characterization` and the tests completed successfully (tests that require `grpcio` are skipped when `grpc` is unavailable).  
- The added tests exercise API shapes, use-case logic, bot behavior, and gRPC client stream handling and validated the expected response and state invariants.  
- No additional unit test failures were introduced by these additions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a68d2a81a0832c947bc79bcc8990f9)