### PR TITLE
Add pre-migration checks target, script, and Rust hardening checklist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: format lint type test test-unit test-integration test-all all setup-dev venv pre-commit-install pre-commit-run check-lock check-openapi check-openapi-validate
+.PHONY: format lint type test test-unit test-integration test-all all setup-dev venv pre-commit-install pre-commit-run check-lock check-openapi check-openapi-validate pre-migration-checks
 
 format:
 	ruff format .
@@ -24,6 +24,9 @@ test-all:
 
 test-fast:
 	pytest tests/ -m "not slow and not integration" -v -x
+
+pre-migration-checks:
+	bash scripts/run_pre_migration_checks.sh
 
 all: format lint type test
 

--- a/docs/plans/rust-pre-migration-checklist.md
+++ b/docs/plans/rust-pre-migration-checklist.md
@@ -1,0 +1,48 @@
+# Rust Pre-Migration Hardening Checklist
+
+This checklist operationalizes the recommendations from `docs/audits/rust-migration-audit.md` into repeatable gates that can be run before each migration slice.
+
+## Phase 1: Lock behavior on critical user flows
+
+- [ ] `/summarize <url>` happy path characterization test stays green.
+- [ ] YouTube transcript fallback characterization test stays green.
+- [ ] `/search` unread/read/unread transition characterization test stays green.
+- [ ] gRPC `SubmitUrl` stream ordering + terminal state characterization test stays green.
+- [ ] API auth and sync response shape characterization tests stay green.
+
+Command:
+
+```bash
+pytest tests/characterization/test_immediate_backlog.py tests/characterization/test_auth_sync_characterization.py -v
+```
+
+## Phase 2: Code-quality debt burn down (desloppify)
+
+- [ ] Run a fresh scan and capture baseline score.
+- [ ] Resolve security findings or document explicit justifications.
+- [ ] Reduce broad/silent exception findings in production paths.
+- [ ] Remove or justify orphaned modules.
+
+Commands:
+
+```bash
+desloppify scan --path .
+desloppify status
+desloppify next --cluster auto/smells-broad_except --count 10
+desloppify next --cluster auto/smells-silent_except --count 10
+desloppify next --cluster auto/orphaned --count 10
+```
+
+## Phase 3: Migration readiness gates
+
+- [ ] Strict score above 60.
+- [ ] Security findings closed or explicitly justified.
+- [ ] Broad/silent exceptions reduced to intentional boundary handlers.
+- [ ] Characterization suite for top flows is green.
+
+## Suggested execution cadence
+
+1. Run characterization tests on every PR touching core request processing.
+2. Run full desloppify scan at least once daily during hardening sprint.
+3. Log score movement and blockers in PR descriptions.
+4. Only start a Rust slice when all migration readiness gates are met.

--- a/scripts/run_pre_migration_checks.sh
+++ b/scripts/run_pre_migration_checks.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if command -v uv >/dev/null 2>&1; then
+  RUNNER=(uv run)
+else
+  RUNNER=()
+fi
+
+echo "==> Running characterization gate tests"
+"${RUNNER[@]}" pytest \
+  tests/characterization/test_immediate_backlog.py \
+  tests/characterization/test_auth_sync_characterization.py \
+  -v
+
+if command -v desloppify >/dev/null 2>&1; then
+  echo "==> Running desloppify migration-readiness snapshot"
+  desloppify scan --path .
+  desloppify status
+else
+  echo "==> Skipping desloppify checks (not installed in current environment)"
+fi


### PR DESCRIPTION
### Motivation

- Provide a repeatable gate to validate behavior and code-quality readiness before Rust migration slices are started.

### Description

- Add `scripts/run_pre_migration_checks.sh` to run characterization pytest cases and an optional `desloppify` snapshot when available.  
- Add a `pre-migration-checks` Makefile target and declare it in `.PHONY` to invoke the script via `make`.  
- Add `docs/plans/rust-pre-migration-checklist.md` documenting the hardening checklist, commands, and migration-readiness gates.

### Testing

- Ran the pre-migration script with `bash scripts/run_pre_migration_checks.sh`, which executed `pytest tests/characterization/test_immediate_backlog.py tests/characterization/test_auth_sync_characterization.py -v`, and the characterization tests passed.  
- Verified that the script skips `desloppify` steps when `desloppify` is not installed and prints a notice (no failure).  
- Verified the new `make pre-migration-checks` target runs the script in the repository root.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a697d13370832cbe46d10c76ba0ccb)